### PR TITLE
MQTT topic router added

### DIFF
--- a/qmqtt.pri
+++ b/qmqtt.pri
@@ -6,7 +6,8 @@ HEADERS += \
     $$PWD/qmqtt_message.h \
     $$PWD/qmqtt_network.h \
     $$PWD/qmqtt_will.h \
-    $$PWD/qmqtt.h
+    $$PWD/qmqtt.h \
+    $$PWD/qmqtt_router.h
 
 SOURCES += \
     $$PWD/qmqtt_client_p.cpp \
@@ -14,4 +15,5 @@ SOURCES += \
     $$PWD/qmqtt_frame.cpp \
     $$PWD/qmqtt_message.cpp \
     $$PWD/qmqtt_network.cpp \
-    $$PWD/qmqtt_will.cpp
+    $$PWD/qmqtt_will.cpp \
+    $$PWD/qmqtt_router.cpp

--- a/qmqtt.pro
+++ b/qmqtt.pro
@@ -18,6 +18,7 @@ SOURCES += qmqtt_client.cpp \
     qmqtt_frame.cpp \
     qmqtt_client_p.cpp \
     qmqtt_message.cpp \
+    qmqtt_router.h \
     qmqtt_will.cpp
 
 HEADERS += qmqtt_client.h\
@@ -27,6 +28,7 @@ HEADERS += qmqtt_client.h\
     qmqtt_client_p.h \
     qmqtt_message.h \
     qmqtt_will.h \
+    qmqtt_router.h \
     qmqtt.h
 
 unix:!symbian {

--- a/qmqtt_message.cpp
+++ b/qmqtt_message.cpp
@@ -33,8 +33,8 @@
 
 namespace QMQTT {
 
-Message::Message(QObject *parent) :
-    QObject(parent),
+Message::Message() :
+    _id(0),
     _qos(0),
     _retain(false),
     _dup(false)
@@ -42,8 +42,7 @@ Message::Message(QObject *parent) :
 }
 
 Message::Message(quint16 id, const QString &topic, const QByteArray &payload,
-            quint8 qos, bool retain, bool dup, QObject *parent) :
-    QObject(parent),
+            quint8 qos, bool retain, bool dup) :
     _id(id),
     _topic(topic),
     _payload(payload),

--- a/qmqtt_message.h
+++ b/qmqtt_message.h
@@ -38,14 +38,12 @@
 
 namespace QMQTT {
 
-class Message : public QObject
+class Message
 {
-    Q_OBJECT
-
 public:
-    Message(QObject *parent = 0);
+    Message();
     Message(quint16 id, const QString &topic, const QByteArray &payload,
-            quint8 qos = 0, bool retain = false, bool dup = false, QObject *parent = 0);
+            quint8 qos = 0, bool retain = false, bool dup = false);
     ~Message();
 
     quint16 id();

--- a/qmqtt_router.cpp
+++ b/qmqtt_router.cpp
@@ -1,0 +1,138 @@
+/*
+ * qmqtt_router.cpp - qmqtt router
+ *
+ * Copyright (c) 2013  Ery Lee <ery.lee at gmail dot com>
+ * Router added by Niklas Wulf <nwulf at geenen-it-systeme dot de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of mqttc nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include "qmqtt_router.h"
+
+#include "qmqtt_client.h"
+#include <QLoggingCategory>
+
+namespace QMQTT {
+
+Q_LOGGING_CATEGORY(router, "qmqtt.router", QtDebugMsg)
+
+Router::Router(Client *parent) : QObject(parent), _client(parent)
+{
+}
+
+RouteSubscription *Router::subscribe(const QString &route)
+{
+    RouteSubscription *subscription = new RouteSubscription(this);
+    subscription->setRoute(route);
+    _client->subscribe(subscription->_topic, 0);
+    connect(_client, &Client::received, subscription, &RouteSubscription::routeMessage);
+    return subscription;
+}
+
+RouteSubscription::RouteSubscription(Router *parent) : QObject(parent)
+{
+}
+
+QString RouteSubscription::route() const
+{
+    return _topic;
+}
+
+void RouteSubscription::setRoute(const QString &route)
+{
+    qCDebug(router) << "Parsing route:" << route;
+
+    QRegularExpression parameterNamesRegExp("\\:([a-zA-Z0-9]+)"); // note how names must not contain dashes or underscores
+
+    // Remove paramter names to get the actual topic "route"
+    QString topic = route;
+    topic.replace(parameterNamesRegExp, "");
+    qCDebug(router) << "Topic:" << topic;
+
+    // Remove the MQTT wildcards to get a regular expression, which matches the parameters
+    QString parameterRegExp = route;
+    parameterRegExp
+            .replace("+", "")
+            .replace(parameterNamesRegExp, "([a-zA-Z0-9_-]+)") // note how parameter values may contain dashes or underscores
+            .replace("#", "")
+            .replace("$", "\\$");
+    qCDebug(router) << "Parameter regexp:" << parameterRegExp;
+
+    // Extract the parameter names
+    QRegularExpressionMatchIterator it = parameterNamesRegExp.globalMatch(route);
+    QStringList names;
+    while(it.hasNext()) {
+        QRegularExpressionMatch match = it.next();
+        QString parameterName = match.captured(1);
+        names << parameterName;
+    }
+    qCDebug(router) << "Parameter names: " << names;
+
+    _topic = topic;
+    _parameterNames = names;
+    _regularExpression = QRegularExpression(parameterRegExp);
+}
+
+void RouteSubscription::routeMessage(const Message &message)
+{
+    QString topic = message.topic();
+    qCDebug(router) << "Routing topic" << topic;
+    QRegularExpressionMatch match = _regularExpression.match(topic);
+    if(!match.hasMatch()) {
+        qCDebug(router) << "No match";
+        return;
+    }
+
+    RoutedMessage routedMessage(message);
+    qCDebug(router) << "Matching paramters:";
+
+    for(int i = 0, c = _parameterNames.size(); i < c; ++i) {
+        QString name = _parameterNames.at(i);
+        QString value = match.captured(i + 1);
+        qCDebug(router) << name << "=" << value;
+
+        routedMessage._parameters.insert(name, value);
+    }
+
+    emit received(routedMessage);
+}
+
+RoutedMessage::RoutedMessage(const Message &message) : _message(message)
+{
+}
+
+const Message &RoutedMessage::message() const
+{
+    return _message;
+}
+
+QHash<QString, QString> RoutedMessage::parameters() const
+{
+    return _parameters;
+}
+
+} // namespace QMQTT
+


### PR DESCRIPTION
Hi again,

Thanks for adding a contributors section to the readme :)

Today I added a topic router to QMQTT. It is inspired by the [mqtt-router](https://www.npmjs.com/package/mqtt-router) node module.

You can use it like this:

````
    void SomeClass::subscribeChanges()
    {
        QMQTT::Client *client = new QMQTT::Client(...);
        QMQTT::Router *router = new QMQTT::Router(client);
        QString route = "Users/+:id/message"
        QMQTT::RouteSubscription *subscription = router->subscribe(route);
        connect(subscription, &QMQTT::RouteSubscription::received, this, &SomeClass::handleUpdateMessage);
    }

    void ListSourceModel::handleUpdateMessage(const QMQTT::RoutedMessage &message)
    {
        QUuid id = message.parameters().value("id");
        qDebug() << "id:"<<id;
    } 
````

Also: Why was Message a QObject? It only has trivially copyable members, which would also make it copyable trivially. Since I need to store the message in my RoutedMessage objects, I changed the base Message class accordingly.