### PR TITLE
Add tests framework

### DIFF
--- a/qmqtt.pro
+++ b/qmqtt.pro
@@ -56,3 +56,25 @@ INSTALLS += headers target
 
 OTHER_FILES += \
     qmqtt.pri
+
+TEST_FILES += \
+    tests/willtests.cpp \
+    tests/willtests.pro \
+    tests/messagetests.cpp \
+    tests/messagetests.pro \
+    tests/frametests.cpp \
+    tests/frametests.pro \
+    tests/routedmessagetests.cpp \
+    tests/routedmessagetests.pro \
+    tests/routertests.cpp \
+    tests/routertests.pro \
+    tests/routesubscriptiontests.cpp \
+    tests/routesubscriptiontests.pro \
+    tests/networktests.cpp \
+    tests/networktests.pro \
+    tests/clienttests.cpp \
+    tests/clienttests.pro \
+    tests/tcpserver.cpp \
+    tests/tcpserver.h
+
+include(tests/tests.pri)

--- a/qmqtt_client.cpp
+++ b/qmqtt_client.cpp
@@ -35,7 +35,7 @@
 
 namespace QMQTT {
 
-Client::Client(const QString & host, quint32 port, QObject * parent /* =0 */)
+Client::Client(const QString host, quint32 port, QObject * parent /* =0 */)
 :d_ptr(new ClientPrivate(this))
 
 {
@@ -247,7 +247,7 @@ void Client::onDisconnected()
 
 //---------------------------------------------
 //---------------------------------------------
-void Client::onReceived(Frame &frame)
+void Client::onReceived(QMQTT::Frame frame)
 {
     quint8 qos = 0;
     bool retain, dup;

--- a/qmqtt_client.h
+++ b/qmqtt_client.h
@@ -92,7 +92,7 @@ class QMQTTSHARED_EXPORT Client : public QObject
 //    friend class ClientPrivate;
 
 public:
-    Client(const QString &host = "localhost", quint32 port = 1883, QObject * parent = 0);
+    Client(const QString host = "localhost", quint32 port = 1883, QObject * parent = 0);
     ~Client();
 
     /*
@@ -144,15 +144,15 @@ signals:
     void error(QAbstractSocket::SocketError);
     void connacked(quint8 ack);
     //send PUBLISH and receive PUBACK
-    void published(QMQTT::Message &message);
+    void published(QMQTT::Message message);
     void pubacked(quint8 type, quint16 msgid);
     //receive PUBLISH
-    void received(const QMQTT::Message &message);
+    void received(const QMQTT::Message message);
     //send SUBSCRIBE and receive SUBACKED
-    void subscribed(const QString &topic);
+    void subscribed(const QString topic);
     void subacked(quint16 mid, quint8 qos);
     //send UNSUBSCRIBE and receive UNSUBACKED
-    void unsubscribed(const QString &topic);
+    void unsubscribed(const QString topic);
     void unsubacked(quint16 mid);
     //receive PINGRESP
     void pong();
@@ -161,7 +161,7 @@ signals:
 private slots:
     void onConnected();
     void onDisconnected();
-    void onReceived(Frame & frame);
+    void onReceived(QMQTT::Frame frame);
     void handlePublish(Message &message);
     void handleConnack(quint8 ack);
     void handlePuback(quint8 type, quint16 msgid);

--- a/qmqtt_client_p.cpp
+++ b/qmqtt_client_p.cpp
@@ -66,10 +66,10 @@ void ClientPrivate::init(QObject * parent)
     QObject::connect(network, SIGNAL(connected()), q, SLOT(onConnected()));
     QObject::connect(network, SIGNAL(error(QAbstractSocket::SocketError)), q, SIGNAL(error(QAbstractSocket::SocketError)));
     QObject::connect(network, SIGNAL(disconnected()), q, SLOT(onDisconnected()));
-    QObject::connect(network, SIGNAL(received(Frame &)), q, SLOT(onReceived(Frame &)));
+    QObject::connect(network, SIGNAL(received(QMQTT::Frame)), q, SLOT(onReceived(QMQTT::Frame)));
 }
 
-void ClientPrivate::init(const QString &host, int port, QObject * parent)
+void ClientPrivate::init(const QString host, int port, QObject * parent)
 {
     this->host = host;
     this->port = port;

--- a/qmqtt_client_p.h
+++ b/qmqtt_client_p.h
@@ -54,7 +54,7 @@ public:
     ClientPrivate(Client * qt);
     ~ClientPrivate();
     void init(QObject * parent = 0);
-    void init(const QString & host, int port, QObject *parent = 0);
+    void init(const QString host, int port, QObject *parent = 0);
 
     QString host;
     quint32 port;

--- a/qmqtt_frame.cpp
+++ b/qmqtt_frame.cpp
@@ -37,31 +37,54 @@ namespace QMQTT {
 
 Q_LOGGING_CATEGORY(frame, "qmqtt.frame")
 
-Frame::Frame(quint8 header, QObject *parent) :
-    QObject(parent),
-    _header(header),
-    _data(QByteArray())
+Frame::Frame()
+    : _header(0)
+    , _data(QByteArray())
 {
 }
 
-Frame::Frame(quint8 header, QByteArray & data, QObject *parent) :
-    QObject(parent),
-    _header(header),
-    _data(data)
+Frame::Frame(quint8 header)
+    : _header(header)
+    , _data(QByteArray())
 {
 }
+
+Frame::Frame(quint8 header, QByteArray data)
+    : _header(header)
+    , _data(data)
+{
+}
+
+Frame::Frame(const Frame& other)
+{
+    _header = other._header;
+    _data = other._data;
+}
+
+Frame& Frame::Frame::operator=(const Frame& other)
+{
+    _header = other._header;
+    _data = other._data;
+    return *this;
+}
+
+bool Frame::operator==(const Frame& other) const
+{
+  return _header == other._header
+      && _data == other._data;
+}
+
 
 Frame::~Frame()
 {
-
 }
 
-quint8 Frame::header()
+quint8 Frame::header() const
 {
     return _header;
 }
 
-QByteArray & Frame::data()
+QByteArray Frame::data() const
 {
     return _data;
 }

--- a/qmqtt_frame.h
+++ b/qmqtt_frame.h
@@ -83,19 +83,21 @@
 
 namespace QMQTT {
 
-class Frame : public QObject
+class Frame
 {
-    Q_OBJECT
-
-    Q_DISABLE_COPY(Frame)
-
 public:
-    explicit Frame(quint8 header, QObject *parent = 0);
-    explicit Frame(quint8 header, QByteArray & data, QObject *parent = 0);
-    ~Frame();
+    explicit Frame();
+    explicit Frame(quint8 header);
+    explicit Frame(quint8 header, QByteArray data);
+    virtual ~Frame();
 
-    quint8 header();
-    QByteArray & data();
+    Frame(const Frame& other);
+    Frame& operator=(const Frame& other);
+
+    bool operator==(const Frame& other) const;
+
+    quint8 header() const;
+    QByteArray data() const;
 
     int readInt();
     char readChar();
@@ -116,5 +118,7 @@ private:
 };
 
 } // namespace QMQTT
+
+Q_DECLARE_METATYPE(QMQTT::Frame);
 
 #endif // QMQTT_FRAME_H

--- a/qmqtt_message.cpp
+++ b/qmqtt_message.cpp
@@ -58,6 +58,16 @@ Message::~Message()
     //NOTHING TODO
 }
 
+bool Message::operator==(const Message& other) const
+{
+  return _id == other._id
+      && _topic == other._topic
+      && _payload == other._payload
+      && _qos == other._qos
+      && _retain == other._retain
+      && _dup == other._dup;
+}
+
 quint16 Message::id()
 {
     return _id;

--- a/qmqtt_message.h
+++ b/qmqtt_message.h
@@ -46,6 +46,8 @@ public:
             quint8 qos = 0, bool retain = false, bool dup = false);
     ~Message();
 
+    bool operator==(const Message& other) const;
+
     quint16 id();
     void setId(quint16 id);
 
@@ -75,5 +77,7 @@ private:
 };
 
 } // namespace QMQTT
+
+Q_DECLARE_METATYPE(QMQTT::Message);
 
 #endif // QMQTT_MESSAGE_H

--- a/qmqtt_network.h
+++ b/qmqtt_network.h
@@ -64,7 +64,7 @@ signals:
     void connected();
     void disconnected();
     void error(QAbstractSocket::SocketError);
-    void received(Frame &frame);
+    void received(QMQTT::Frame frame);
 
 public slots:
     void connectTo(const QString & host, quint32 port);

--- a/tests/clienttests.cpp
+++ b/tests/clienttests.cpp
@@ -1,0 +1,858 @@
+#include "tcpserver.h"
+#include "qmqtt_client.h"
+#include <QTest>
+#include <QObject>
+#include <QSharedPointer>
+#include <QTcpServer>
+#include <QSignalSpy>
+
+class ClientTests : public QObject
+{
+    Q_OBJECT
+public:
+    explicit ClientTests();
+    virtual ~ClientTests();
+
+    QSharedPointer<QMQTT::Client> _uut;
+
+    void flushEvents();
+    QSharedPointer<QTcpServer> createTcpServer();
+    void connectClientToServer(QSharedPointer<QMQTT::Client> client,
+                               QSharedPointer<QTcpServer> server);
+    void disconnectServerAndWaitForDisconnect(QSharedPointer<QTcpServer> server);
+    quint64 readEncodedLength(QDataStream& in);
+    quint8 readByte(QDataStream& in);
+    void writeByte(QDataStream& out, quint8 byte);
+    quint16 readInt(QDataStream& in);
+    void writeInt(QDataStream& out, quint16 i);
+    QByteArray readByteArray(QDataStream& in, const quint64 length);
+    void writeByteArray(QDataStream& out, const QByteArray byteArray);
+    QString readString(QDataStream& in);
+    void writeString(QDataStream& out, const QString string);
+
+private slots:
+    void init();
+    void cleanup();
+
+    void constructorWithNoParameters_Test();
+    void constructorWithHost_Test();
+    void constructorWithHostAndPort_Test();
+    void constructorWithHostPortAndParent_Test();
+    // setters and getter tests
+    void hostReturnsHostValue_Test();
+    void portReturnsPortValue_Test();
+    void setHostSetsHostValue_Test();
+    void setPortSetsPortValue_Test();
+    void clientIdReturnsClientId_Test();
+    void setClientIdSetsClientId_Test();
+    void usernameReturnsUsername_Test();
+    void setUsernameSetsUsername_Test();
+    void passwordReturnsPassword_Test();
+    void setPasswordSetsPassword_Test();
+    void keepaliveReturnsKeepAlive_Test();
+    void setKeepAliveSetsKeepAlive_Test();
+    void cleansessReturnsCleansess_Test();
+    void setCleansessSetsCleansess_Test();
+    void connectWillMakeTCPConnection_Test();
+    void isConnectedIsFalseWhenNotConnected_Test();
+    void isConnectedIsTrueWhenConnected_Test();
+    void autoReconnectDefaultsToFalse_Test();
+    void autoReconnectCanBeSetToTrue_Test();
+    void autoReconnectDoesNotReconnect_Test();
+    void willDefaultsToNull_Test();
+    void setWillSetsAWill_Test();
+    void stateDefaultsToStateInit_Test();
+    void stateRemainsInStateInitWhenConnected_Test();
+    // message send tests
+    void connectSendsConnectMessage_Test();
+    void publishSendsPublishMessage_Test();
+    void subscribeSendsSubscribeMessage_Test();
+    void pubackSendsPubackMessage_Test();
+    void unsubscribeSendsUnsubscribeMessage_Test();
+    void disconnectSendsDisconnectMessage_Test();
+    void pingSendsPingMessage_Test();
+    // signals tests
+    void connectEmitsConnectedSignal_Test();
+    void tcpSocketErrorEmitsErrorSignal_Test();
+    void receivingConnackEmitsConnackedSignal_Test();
+    void publishEmitsPublishedSignal_Test();
+    void receivingPubackEmitsPubackedSignal_Test();
+    void receivingPublishEmitsReceivedSignal_Test();
+    void subscribeEmitsSubscribedSignal_Test();
+    void receivingSubackEmitsSubackedSignal_Test();
+    void unsubscribeEmitsUnsubscribedSignal_Test();
+    void receivingUnsubackEmitsUnsubackedSignal_Test();
+    void receivingPingrespEmitsPongSignal_Test();
+    void tcpSocketDisconnectEmitsDisconnectedSignal_Test();
+};
+
+ClientTests::ClientTests()
+    : _uut(NULL)
+{
+}
+
+ClientTests::~ClientTests()
+{
+}
+
+void ClientTests::init()
+{
+    _uut.reset(new QMQTT::Client);
+}
+
+void ClientTests::cleanup()
+{
+    _uut.reset();
+}
+
+void ClientTests::flushEvents()
+{
+    while (QCoreApplication::hasPendingEvents())
+    {
+        QCoreApplication::processEvents(QEventLoop::AllEvents);
+        QCoreApplication::sendPostedEvents(0, QEvent::DeferredDelete);
+    }
+}
+
+QSharedPointer<QTcpServer> ClientTests::createTcpServer()
+{
+    QSharedPointer<QTcpServer> server = QSharedPointer<QTcpServer>(new QTcpServer);
+    server->listen(QHostAddress::LocalHost, static_cast<quint16>(8973));
+    return server;
+}
+
+void ClientTests::connectClientToServer(QSharedPointer<QMQTT::Client> client,
+                                        QSharedPointer<QTcpServer> server)
+{
+    client->setHost(server->serverAddress().toString());
+    client->setPort(server->serverPort());
+    client->connect();
+}
+
+void ClientTests::disconnectServerAndWaitForDisconnect(QSharedPointer<QTcpServer> server)
+{
+    QTcpSocket* socket = server->nextPendingConnection();
+    socket->disconnectFromHost();
+    socket->state() == QAbstractSocket::UnconnectedState
+        || socket->waitForDisconnected(5000);
+}
+
+const quint8 CONNECT_TYPE = 0x10;
+const quint8 CONNACK_TYPE = 0x20;
+const quint8 PUBLISH_TYPE = 0x30;
+const quint8 PUBACK_TYPE = 0x40;
+const quint8 PUBREC_TYPE = 0x50;
+const quint8 PUBREL_TYPE = 0x60;
+const quint8 PUBCOMP_TYPE = 0x70;
+const quint8 SUBSCRIBE_TYPE = 0x80;
+const quint8 SUBACK_TYPE = 0x90;
+const quint8 UNSUBSCRIBE_TYPE = 0xA0;
+const quint8 UNSUBACK_TYPE = 0xB0;
+const quint8 PINGREQ_TYPE = 0xC0;
+const quint8 PINGRESP_TYPE = 0xD0;
+const quint8 DISCONNECT_TYPE = 0xE0;
+const quint8 QOS0 = 0x00;
+const quint8 QOS1 = 0x02;
+const quint8 QOS2 = 0x04;
+
+quint64 ClientTests::readEncodedLength(QDataStream& in)
+{
+    quint64 length = 0;
+    quint8 byte = 0;
+    int shift = 0;
+    do {
+        in >> byte;
+        length |= (byte & 0x7f) << shift;
+        shift += 7;
+    } while (byte & 0x80);
+    return length;
+}
+
+quint8 ClientTests::readByte(QDataStream& in)
+{
+    quint8 byte = 0;
+    in >> byte;
+    return byte;
+}
+
+void ClientTests::writeByte(QDataStream& out, quint8 byte)
+{
+    out << byte;
+}
+
+quint16 ClientTests::readInt(QDataStream& in)
+{
+    quint16 i = 0;
+    in >> i;
+    return i;
+}
+
+void ClientTests::writeInt(QDataStream& out, const quint16 i)
+{
+    out << i;
+}
+
+QByteArray ClientTests::readByteArray(QDataStream& in, const quint64 length)
+{
+    QByteArray byteArray(length, ' ');
+    int actualLength = in.readRawData(byteArray.data(), length);
+    byteArray.resize(actualLength);
+    return byteArray;
+}
+
+void ClientTests::writeByteArray(QDataStream& out, const QByteArray byteArray)
+{
+    out.writeRawData(byteArray.constData(), byteArray.size());
+}
+
+QString ClientTests::readString(QDataStream& in)
+{
+    quint16 length = readInt(in);
+    return QString::fromUtf8(readByteArray(in, length));
+}
+
+void ClientTests::writeString(QDataStream& out, const QString string)
+{
+    QByteArray byteArray = string.toUtf8();
+    writeInt(out, byteArray.size());
+    writeByteArray(out, byteArray);
+}
+
+void ClientTests::constructorWithNoParameters_Test()
+{
+    // todo: eliminate annoying pass by reference in constructor
+    QString host("localhost");
+    QCOMPARE(_uut->host(), host);
+    QCOMPARE(_uut->port(), static_cast<quint32>(1883));
+    QVERIFY(NULL == _uut->parent());
+}
+
+void ClientTests::constructorWithHost_Test()
+{
+    _uut.reset(new QMQTT::Client("8.8.8.8"));
+
+    QString host("8.8.8.8");
+    QCOMPARE(_uut->host(), host);
+    QCOMPARE(_uut->port(), static_cast<quint32>(1883));
+    QVERIFY(NULL == _uut->parent());
+}
+
+void ClientTests::constructorWithHostAndPort_Test()
+{
+    _uut.reset(new QMQTT::Client("8.8.8.8", 8883));
+
+    QString host("8.8.8.8");
+    QCOMPARE(_uut->host(), host);
+    QCOMPARE(_uut->port(), static_cast<quint32>(8883));
+    QVERIFY(NULL == _uut->parent());
+}
+
+void ClientTests::constructorWithHostPortAndParent_Test()
+{
+    QObject parent;
+    _uut.reset(new QMQTT::Client("8.8.8.8", 8883, &parent));
+
+    QString host("8.8.8.8");
+    QCOMPARE(_uut->host(), host);
+    QCOMPARE(_uut->port(), static_cast<quint32>(8883));
+    QCOMPARE(_uut->parent(), &parent);
+    _uut.reset();
+}
+
+void ClientTests::hostReturnsHostValue_Test()
+{
+    QString host("localhost");
+    QCOMPARE(_uut->host(), host);
+}
+
+void ClientTests::setHostSetsHostValue_Test()
+{
+    QString host("8.8.8.8");
+    _uut->setHost(host);
+    QCOMPARE(_uut->host(), host);
+}
+
+void ClientTests::portReturnsPortValue_Test()
+{
+    QCOMPARE(_uut->port(), static_cast<quint32>(1883));
+}
+
+void ClientTests::setPortSetsPortValue_Test()
+{
+    _uut->setPort(8883);
+    QCOMPARE(_uut->port(), static_cast<quint32>(8883));
+}
+
+void ClientTests::clientIdReturnsClientId_Test()
+{
+    QCOMPARE(_uut->clientId(), QString());
+}
+
+void ClientTests::setClientIdSetsClientId_Test()
+{
+    _uut->setClientId("Client");
+    QCOMPARE(_uut->clientId(), QString("Client"));
+}
+
+void ClientTests::usernameReturnsUsername_Test()
+{
+    QCOMPARE(_uut->username(), QString());
+}
+
+void ClientTests::setUsernameSetsUsername_Test()
+{
+    _uut->setUsername("Username");
+    QCOMPARE(_uut->username(), QString("Username"));
+}
+
+void ClientTests::passwordReturnsPassword_Test()
+{
+    QCOMPARE(_uut->password(), QString());
+}
+
+void ClientTests::setPasswordSetsPassword_Test()
+{
+    _uut->setPassword("Password");
+    QCOMPARE(_uut->password(), QString("Password"));
+}
+
+void ClientTests::keepaliveReturnsKeepAlive_Test()
+{
+    QCOMPARE(_uut->keepalive(), 300);
+}
+
+void ClientTests::setKeepAliveSetsKeepAlive_Test()
+{
+    _uut->setKeepAlive(400);
+    QCOMPARE(_uut->keepalive(), 400);
+}
+
+void ClientTests::cleansessReturnsCleansess_Test()
+{
+    QCOMPARE(_uut->cleansess(), false);
+}
+
+void ClientTests::setCleansessSetsCleansess_Test()
+{
+    _uut->setCleansess(true);
+    QCOMPARE(_uut->cleansess(), true);
+}
+
+void ClientTests::connectWillMakeTCPConnection_Test()
+{
+    QSharedPointer<QTcpServer> server = createTcpServer();
+    connectClientToServer(_uut, server);
+    bool connected = server->waitForNewConnection(5000);
+
+    QCOMPARE(connected, true);
+}
+
+void ClientTests::isConnectedIsFalseWhenNotConnected_Test()
+{
+    QCOMPARE(_uut->isConnected(), false);
+}
+
+void ClientTests::isConnectedIsTrueWhenConnected_Test()
+{
+    QSharedPointer<QTcpServer> server = createTcpServer();
+    connectClientToServer(_uut, server);
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    QCOMPARE(_uut->isConnected(), true);
+}
+
+void ClientTests::autoReconnectDefaultsToFalse_Test()
+{
+    QCOMPARE(_uut->autoReconnect(), false);
+}
+
+void ClientTests::autoReconnectCanBeSetToTrue_Test()
+{
+    _uut->setAutoReconnect(true);
+    QCOMPARE(_uut->autoReconnect(), true);
+}
+
+void ClientTests::autoReconnectDoesNotReconnect_Test()
+{
+    QSharedPointer<QTcpServer> server = createTcpServer();
+    connectClientToServer(_uut, server);
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    QCOMPARE(_uut->isConnected(), true);
+
+    disconnectServerAndWaitForDisconnect(server);
+
+    flushEvents();
+    QCOMPARE(_uut->isConnected(), false);
+}
+
+void ClientTests::willDefaultsToNull_Test()
+{
+    QVERIFY(NULL == _uut->will());
+}
+
+void ClientTests::setWillSetsAWill_Test()
+{
+    _uut->setWill(new QMQTT::Will("topic", "message", 123, true));
+
+    QVERIFY(NULL != _uut->will());
+    QCOMPARE(_uut->will()->qos(), static_cast<quint8>(123));
+    QCOMPARE(_uut->will()->retain(), true);
+    QCOMPARE(_uut->will()->topic(), QString("topic"));
+    QCOMPARE(_uut->will()->message(), QString("message"));
+}
+
+void ClientTests::stateDefaultsToStateInit_Test()
+{
+    QCOMPARE(_uut->state(), QMQTT::STATE_INIT);
+}
+
+// todo: unused state variable for now
+void ClientTests::stateRemainsInStateInitWhenConnected_Test()
+{
+    QSharedPointer<QTcpServer> server = createTcpServer();
+    connectClientToServer(_uut, server);
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    QCOMPARE(_uut->state(), QMQTT::STATE_INIT);
+}
+
+void ClientTests::connectSendsConnectMessage_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    QByteArray byteArray = server->data();
+    QDataStream in(&byteArray, QBuffer::ReadOnly);
+
+    quint8 header = readByte(in);
+    quint64 numberOfBytes = readEncodedLength(in);
+    readByteArray(in, numberOfBytes);
+    QCOMPARE(header, static_cast<quint8>(CONNECT_TYPE | QOS1));
+}
+
+void ClientTests::publishSendsPublishMessage_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    QByteArray payload("payload");
+    QMQTT::Message message(222, "topic", payload);
+    _uut->publish(message);
+    flushEvents();
+
+    QByteArray byteArray = server->data();
+    QDataStream in(&byteArray, QBuffer::ReadOnly);
+
+    quint8 header = readByte(in);
+    quint64 numberOfBytes = readEncodedLength(in);
+    readByteArray(in, numberOfBytes);
+    QCOMPARE(header, static_cast<quint8>(CONNECT_TYPE | QOS1));
+
+    header = readByte(in);
+    numberOfBytes = readEncodedLength(in);
+    readByteArray(in, numberOfBytes);
+    QCOMPARE(header, static_cast<quint8>(PUBLISH_TYPE | QOS0));
+}
+
+void ClientTests::subscribeSendsSubscribeMessage_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    _uut->subscribe("topic", QOS2);
+    flushEvents();
+
+    QByteArray byteArray = server->data();
+    QDataStream in(&byteArray, QBuffer::ReadOnly);
+
+    quint8 header = readByte(in);
+    quint64 numberOfBytes = readEncodedLength(in);
+    readByteArray(in, numberOfBytes);
+    QCOMPARE(header, static_cast<quint8>(CONNECT_TYPE | QOS1));
+
+    header = readByte(in);
+    numberOfBytes = readEncodedLength(in);
+    readByteArray(in, numberOfBytes);
+    QCOMPARE(header, static_cast<quint8>(SUBSCRIBE_TYPE | QOS1));
+}
+
+// all these under puback
+//    void puback(quint8 type, quint16 msgid);
+//    void pubrec(int msgid);
+//    void pubrel(int msgid);
+//    void pubcomp(int msgid);
+void ClientTests::pubackSendsPubackMessage_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    _uut->puback(PUBACK, 42);
+    flushEvents();
+
+    QByteArray byteArray = server->data();
+    QDataStream in(&byteArray, QBuffer::ReadOnly);
+
+    quint8 header = readByte(in);
+    quint64 numberOfBytes = readEncodedLength(in);
+    readByteArray(in, numberOfBytes);
+    QCOMPARE(header, static_cast<quint8>(CONNECT_TYPE | QOS1));
+
+    header = readByte(in);
+    numberOfBytes = readEncodedLength(in);
+    readByteArray(in, numberOfBytes);
+    QCOMPARE(header, static_cast<quint8>(PUBACK_TYPE | QOS0));
+}
+
+void ClientTests::unsubscribeSendsUnsubscribeMessage_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    _uut->unsubscribe("topic");
+    flushEvents();
+
+    QByteArray byteArray = server->data();
+    QDataStream in(&byteArray, QBuffer::ReadOnly);
+
+    quint8 header = readByte(in);
+    quint64 numberOfBytes = readEncodedLength(in);
+    readByteArray(in, numberOfBytes);
+    QCOMPARE(header, static_cast<quint8>(CONNECT_TYPE | QOS1));
+
+    header = readByte(in);
+    numberOfBytes = readEncodedLength(in);
+    readByteArray(in, numberOfBytes);
+    QCOMPARE(header, static_cast<quint8>(UNSUBSCRIBE_TYPE | QOS1));
+}
+
+// todo: what happens if not already subscribed?
+
+void ClientTests::disconnectSendsDisconnectMessage_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    _uut->disconnect();
+    flushEvents();
+
+    QByteArray byteArray = server->data();
+    QDataStream in(&byteArray, QBuffer::ReadOnly);
+
+    quint8 header = readByte(in);
+    quint64 numberOfBytes = readEncodedLength(in);
+    readByteArray(in, numberOfBytes);
+    QCOMPARE(header, static_cast<quint8>(CONNECT_TYPE | QOS1));
+
+    header = readByte(in);
+    numberOfBytes = readEncodedLength(in);
+    readByteArray(in, numberOfBytes);
+    QCOMPARE(header, static_cast<quint8>(DISCONNECT_TYPE | QOS0));
+}
+
+void ClientTests::pingSendsPingMessage_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    _uut->ping();
+    flushEvents();
+
+    QByteArray byteArray = server->data();
+    QDataStream in(&byteArray, QBuffer::ReadOnly);
+
+    quint8 header = readByte(in);
+    quint64 numberOfBytes = readEncodedLength(in);
+    readByteArray(in, numberOfBytes);
+    QCOMPARE(header, static_cast<quint8>(CONNECT_TYPE | QOS1));
+
+    header = readByte(in);
+    numberOfBytes = readEncodedLength(in);
+    readByteArray(in, numberOfBytes);
+    QCOMPARE(header, static_cast<quint8>(PINGREQ_TYPE | QOS0));
+}
+
+void ClientTests::connectEmitsConnectedSignal_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    QSignalSpy spy(_uut.data(), &QMQTT::Client::connected);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    QCOMPARE(spy.count(), 1);
+}
+
+void ClientTests::tcpSocketErrorEmitsErrorSignal_Test()
+{
+    QSignalSpy spy(_uut.data(), &QMQTT::Client::error);
+
+    _uut->setHost(QHostAddress(TcpServer::HOST).toString());
+    _uut->setPort(TcpServer::PORT);
+    _uut->connect();
+
+    flushEvents();
+
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.at(0).at(0).value<QAbstractSocket::SocketError>(), QAbstractSocket::ConnectionRefusedError);
+}
+
+// todo: connect starts keepalive
+
+void ClientTests::receivingConnackEmitsConnackedSignal_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    QSignalSpy spy(_uut.data(), &QMQTT::Client::connacked);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    QMQTT::Frame frame(CONNACK_TYPE, QByteArray(2, 0x0));
+    QDataStream out(server->socket());
+    frame.write(out);
+    server->socket()->waitForBytesWritten(5000);
+    flushEvents();
+
+    QCOMPARE(spy.count(), 1);
+    // todo: compare data received?
+}
+
+// todo: connack, connection accepted
+// todo: connack, connection refused, unnacceptable protocol
+// todo: connack, connection refused, identifier rejected
+
+void ClientTests::publishEmitsPublishedSignal_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    qRegisterMetaType<QMQTT::Message>("QMQTT::Message");
+    QSignalSpy spy(_uut.data(), &QMQTT::Client::published);
+
+    QByteArray payload("payload");
+    QMQTT::Message message(222, "topic", payload);
+    _uut->publish(message);
+    flushEvents();
+
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.at(0).at(0).value<QMQTT::Message>(), message);
+}
+
+void ClientTests::receivingPubackEmitsPubackedSignal_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    qRegisterMetaType<QMQTT::Message>("QMQTT::Message");
+    QSignalSpy spy(_uut.data(), &QMQTT::Client::pubacked);
+
+    QMQTT::Frame frame(PUBACK_TYPE, QByteArray(2, 0x0));
+    QDataStream out(server->socket());
+    frame.write(out);
+    server->socket()->waitForBytesWritten(5000);
+    flushEvents();
+
+    QCOMPARE(spy.count(), 1);
+    // todo: compare data received?
+}
+
+void ClientTests::receivingPublishEmitsReceivedSignal_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    QSignalSpy spy(_uut.data(), &QMQTT::Client::received);
+
+    QByteArray variableHeader;
+    QDataStream variableHeaderDataStream(&variableHeader, QIODevice::WriteOnly);
+    writeString(variableHeaderDataStream, "topic");
+    QMQTT::Frame frame(PUBLISH_TYPE, variableHeader);
+    QDataStream out(server->socket());
+    frame.write(out);
+
+    server->socket()->waitForBytesWritten(5000);
+    flushEvents();
+
+    QCOMPARE(spy.count(), 1);
+    // todo: compare data received?
+}
+
+void ClientTests::subscribeEmitsSubscribedSignal_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    QSignalSpy spy(_uut.data(), &QMQTT::Client::subscribed);
+
+    _uut->subscribe("topic", QOS2);
+    flushEvents();
+
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.at(0).at(0).toString(), QString("topic"));
+}
+
+void ClientTests::receivingSubackEmitsSubackedSignal_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    QSignalSpy spy(_uut.data(), &QMQTT::Client::subacked);
+
+    QByteArray variableHeader;
+    QDataStream variableHeaderDataStream(&variableHeader, QIODevice::WriteOnly);
+    writeInt(variableHeaderDataStream, 0);
+    writeByte(variableHeaderDataStream, 0x00);
+    QMQTT::Frame frame(SUBACK_TYPE, variableHeader);
+    QDataStream out(server->socket());
+    frame.write(out);
+
+    server->socket()->waitForBytesWritten(5000);
+    flushEvents();
+
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.at(0).at(0).value<quint8>(), QOS0);
+}
+
+void ClientTests::unsubscribeEmitsUnsubscribedSignal_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    QSignalSpy spy(_uut.data(), &QMQTT::Client::unsubscribed);
+
+    _uut->unsubscribe("topic");
+    flushEvents();
+
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.at(0).at(0).toString(), QString("topic"));
+}
+
+void ClientTests::receivingUnsubackEmitsUnsubackedSignal_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    QSignalSpy spy(_uut.data(), &QMQTT::Client::unsubacked);
+
+    QByteArray variableHeader;
+    QDataStream variableHeaderDataStream(&variableHeader, QIODevice::WriteOnly);
+    writeInt(variableHeaderDataStream, 13);
+    QMQTT::Frame frame(UNSUBACK_TYPE, variableHeader);
+    QDataStream out(server->socket());
+    frame.write(out);
+
+    server->socket()->waitForBytesWritten(5000);
+    flushEvents();
+
+    QCOMPARE(spy.count(), 1);
+    // todo: msg id is always zero, it appears
+    QCOMPARE(spy.at(0).at(0).value<quint16>(), static_cast<quint16>(0));
+}
+
+void ClientTests::receivingPingrespEmitsPongSignal_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    QSignalSpy spy(_uut.data(), &QMQTT::Client::pong);
+
+    QByteArray variableHeader;
+    QMQTT::Frame frame(PINGRESP_TYPE, variableHeader);
+    QDataStream out(server->socket());
+    frame.write(out);
+
+    server->socket()->waitForBytesWritten(5000);
+    flushEvents();
+
+    QCOMPARE(spy.count(), 1);
+}
+
+void ClientTests::tcpSocketDisconnectEmitsDisconnectedSignal_Test()
+{
+    QSharedPointer<TcpServer> server = QSharedPointer<TcpServer>(new TcpServer);
+
+    connectClientToServer(_uut, server);
+
+    server->waitForNewConnection(5000);
+    flushEvents();
+
+    QSignalSpy spy(_uut.data(), &QMQTT::Client::disconnected);
+
+    server->socket()->disconnectFromHost();
+    server->socket()->waitForDisconnected(5000);
+    flushEvents();
+
+    QCOMPARE(spy.count(), 1);
+}
+
+QTEST_MAIN(ClientTests);
+#include "clienttests.moc"

--- a/tests/clienttests.pro
+++ b/tests/clienttests.pro
@@ -1,0 +1,9 @@
+QT += widgets testlib network
+QT -= gui
+TARGET = clienttests
+DEFINES += QMQTT_LIBRARY_TESTS
+CONFIG += testcase
+SOURCES += tcpserver.cpp clienttests.cpp
+HEADERS += tcpserver.h
+INCLUDEPATH += ..
+LIBS += -L.. -lqmqtt

--- a/tests/frametests.cpp
+++ b/tests/frametests.cpp
@@ -1,0 +1,159 @@
+#include <qmqtt_frame.h>
+#include <QTest>
+#include <QScopedPointer>
+
+class FrameTests : public QObject
+{
+    Q_OBJECT
+public:
+    explicit FrameTests();
+    virtual ~FrameTests();
+
+    QScopedPointer<QMQTT::Frame> _uut;
+
+private slots:
+    void init();
+    void cleanup();
+
+    void defaultConstructor_Test();
+    void constructorWithParameters_Test();
+
+    // todo: copy constructor
+    // todo: assignment operator
+    // todo: equality operator
+
+    void readIntReadsBytearray_Test();
+    void readCharReadsBytearray_Test();
+    void readStringReadsBytearray_Test();
+
+    void writeIntWritesToBytearray_Test();
+    void writeCharWritesToBytearray_Test();
+    void writeStringWritesToBytearray_Test();
+    void writeRawDataWritesToBytearray_Test();
+    void writeWritesToDatastream_Test();
+};
+
+FrameTests::FrameTests()
+    : _uut(NULL)
+{
+}
+
+FrameTests::~FrameTests()
+{
+}
+
+void FrameTests::init()
+{
+    _uut.reset(new QMQTT::Frame(0));
+}
+
+void FrameTests::cleanup()
+{
+    _uut.reset();
+}
+
+void FrameTests::defaultConstructor_Test()
+{
+    QSKIP("Disabled test, getters segfault");
+    // todo: these segfault currently. QByteArray contains no data when default constructed.
+    // QCOMPARE(_uut->readInt(), 0);
+    // QCOMPARE(_uut->readChar(), static_cast<char>(12));
+    // QCOMPARE(_uut->readString(), QString("blah"));
+}
+
+void FrameTests::constructorWithParameters_Test()
+{
+    QByteArray byteArray;
+    _uut.reset(new QMQTT::Frame(0, byteArray));
+
+    QCOMPARE(_uut.isNull(), false);
+}
+
+void FrameTests::readIntReadsBytearray_Test()
+{
+    QByteArray byteArray;
+    byteArray.resize(2);
+    byteArray[0] = 1;
+    byteArray[1] = 2;
+    _uut.reset(new QMQTT::Frame(0, byteArray));
+
+    QCOMPARE(_uut->readInt(), static_cast<int>((1 << 8) + 2));
+}
+
+void FrameTests::readCharReadsBytearray_Test()
+{
+    QByteArray byteArray;
+    byteArray.resize(1);
+    byteArray[0] = 42;
+    _uut.reset(new QMQTT::Frame(0, byteArray));
+
+    QCOMPARE(_uut->readChar(), static_cast<char>(42));
+}
+
+void FrameTests::readStringReadsBytearray_Test()
+{
+    QByteArray byteArray;
+    byteArray.resize(5);
+    byteArray[0] = 0;
+    byteArray[1] = 3;
+    byteArray[2] = 'a';
+    byteArray[3] = 'b';
+    byteArray[4] = 'c';
+    _uut.reset(new QMQTT::Frame(0, byteArray));
+
+    QCOMPARE(_uut->readString(), QString("abc"));
+}
+
+void FrameTests::writeIntWritesToBytearray_Test()
+{
+    _uut->writeInt(42);
+
+    QCOMPARE(_uut->readInt(), 42);
+}
+
+void FrameTests::writeCharWritesToBytearray_Test()
+{
+    _uut->writeChar(static_cast<char>(42));
+
+    QCOMPARE(_uut->readChar(), static_cast<char>(42));
+}
+
+void FrameTests::writeStringWritesToBytearray_Test()
+{
+    _uut->writeString(QString("forty-two"));
+
+    QCOMPARE(_uut->readString(), QString("forty-two"));
+}
+
+void FrameTests::writeRawDataWritesToBytearray_Test()
+{
+    QByteArray byteArray;
+    byteArray.resize(2);
+    byteArray[0] = 3;
+    byteArray[1] = 4;
+    _uut->writeRawData(byteArray);
+
+    QCOMPARE(_uut->readInt(), static_cast<int>((3 << 8) + 4));
+}
+
+void FrameTests::writeWritesToDatastream_Test()
+{
+    QByteArray frameData(128, 0);
+    for (unsigned char c = 0; c < 128; c++)
+    {
+        frameData[c] = c;
+    }
+    _uut.reset(new QMQTT::Frame(0, frameData));
+
+    QByteArray streamedData;
+    QDataStream stream(&streamedData, QIODevice::WriteOnly);
+    _uut->write(stream);
+
+    QCOMPARE(static_cast<quint8>(streamedData.at(0)), static_cast<quint8>(0));
+    QCOMPARE(static_cast<quint8>(streamedData.at(1)), static_cast<quint8>(0x80));
+    QCOMPARE(static_cast<quint8>(streamedData.at(2)), static_cast<quint8>(0x01));
+    QCOMPARE(streamedData.mid(3), frameData);
+}
+
+QTEST_MAIN(FrameTests);
+#include "frametests.moc"

--- a/tests/frametests.pro
+++ b/tests/frametests.pro
@@ -1,0 +1,8 @@
+QT += widgets testlib
+QT -= gui
+DEFINES += QMQTT_LIBRARY_TESTS
+TARGET = frametests
+CONFIG += testcase
+SOURCES += frametests.cpp
+INCLUDEPATH += ..
+LIBS += -L.. -lqmqtt

--- a/tests/messagetests.cpp
+++ b/tests/messagetests.cpp
@@ -1,0 +1,122 @@
+#include <qmqtt_message.h>
+#include <QTest>
+#include <QScopedPointer>
+
+namespace QMQTT
+{
+    class Message;
+}
+
+class MessageTests : public QObject
+{
+    Q_OBJECT
+public:
+    explicit MessageTests();
+    virtual ~MessageTests();
+
+    QScopedPointer<QMQTT::Message> _uut;
+
+private slots:
+    void init();
+    void cleanup();
+
+    void defaultConstructor_Test();
+    void constructorWithParametersHasDefaultValues_Test();
+    void constructorWithParameters_Test();
+
+    // todo: equality operator
+
+    void idSettable_Test();
+    void qosSettable_Test();
+    void retainSettable_Test();
+    void dupSettable_Test();
+    void topicSettable_Test();
+    void payloadSettable_Test();
+};
+
+MessageTests::MessageTests()
+    : _uut(NULL)
+{
+}
+
+MessageTests::~MessageTests()
+{
+}
+
+void MessageTests::init()
+{
+    _uut.reset(new QMQTT::Message);
+}
+
+void MessageTests::cleanup()
+{
+    _uut.reset();
+}
+
+void MessageTests::defaultConstructor_Test()
+{
+    QCOMPARE(_uut->id(), static_cast<quint16>(0));
+    QCOMPARE(_uut->qos(), static_cast<quint8>(0));
+    QCOMPARE(_uut->retain(), false);
+    QCOMPARE(_uut->dup(), false);
+    QCOMPARE(_uut->topic(), QString());
+    QCOMPARE(_uut->payload(), QByteArray());
+}
+
+void MessageTests::constructorWithParametersHasDefaultValues_Test()
+{
+    _uut.reset(new QMQTT::Message(5, "topic", QString("payload").toUtf8()));
+    QCOMPARE(_uut->qos(), static_cast<quint8>(0));
+    QCOMPARE(_uut->retain(), false);
+    QCOMPARE(_uut->dup(), false);
+}
+
+void MessageTests::constructorWithParameters_Test()
+{
+    _uut.reset(new QMQTT::Message(5, "topic", QString("payload").toUtf8(), 5, true, true));
+    QCOMPARE(_uut->id(), static_cast<quint16>(5));
+    QCOMPARE(_uut->qos(), static_cast<quint8>(5));
+    QCOMPARE(_uut->retain(), true);
+    QCOMPARE(_uut->dup(), true);
+    QCOMPARE(_uut->topic(), QString("topic"));
+    QCOMPARE(_uut->payload(), QByteArray("payload"));
+}
+
+void MessageTests::idSettable_Test()
+{
+    _uut->setId(5);
+    QCOMPARE(_uut->id(), static_cast<quint16>(5));
+}
+
+void MessageTests::qosSettable_Test()
+{
+    _uut->setQos(5);
+    QCOMPARE(_uut->qos(), static_cast<quint8>(5));
+}
+
+void MessageTests::retainSettable_Test()
+{
+    _uut->setRetain(true);
+    QCOMPARE(_uut->retain(), true);
+}
+
+void MessageTests::dupSettable_Test()
+{
+    _uut->setDup(true);
+    QCOMPARE(_uut->dup(), true);
+}
+
+void MessageTests::topicSettable_Test()
+{
+    _uut->setTopic("topic");
+    QCOMPARE(_uut->topic(), QString("topic"));
+}
+
+void MessageTests::payloadSettable_Test()
+{
+    _uut->setPayload("payload");
+    QCOMPARE(_uut->payload(), QByteArray("payload"));
+}
+
+QTEST_MAIN(MessageTests);
+#include "messagetests.moc"

--- a/tests/messagetests.pro
+++ b/tests/messagetests.pro
@@ -1,0 +1,8 @@
+QT += widgets testlib
+QT -= gui
+DEFINES += QMQTT_LIBRARY_TESTS
+TARGET = messagetests
+CONFIG += testcase
+SOURCES += messagetests.cpp
+INCLUDEPATH += ..
+LIBS += -L.. -lqmqtt

--- a/tests/networktests.cpp
+++ b/tests/networktests.cpp
@@ -1,0 +1,268 @@
+#include "tcpserver.h"
+#include <qmqtt_network.h>
+#include <qmqtt_frame.h>
+#include <QTest>
+#include <QSignalSpy>
+#include <QDebug>
+#include <QObject>
+#include <QScopedPointer>
+
+class NetworkTests : public QObject
+{
+    Q_OBJECT
+public:
+    explicit NetworkTests();
+    virtual ~NetworkTests();
+
+    QScopedPointer<QMQTT::Network> _uut;
+
+private:
+    void flushEvents();
+    QByteArray serializeFrame(QMQTT::Frame& frame) const;
+
+private slots:
+    void init();
+    void cleanup();
+
+    void defaultConstructor_Test();
+    void connectToMakesTCPConnection_Test();
+    void connectedSignalEmittedAfterConnectionMade_Test();
+    void isConnectedTrueWhenInConnectedState_Test();
+    void isConnectedFalseWhenNotInConnectedState_Test();
+    void disconnectWillDisconnectASocketConnection_Test();
+    void disconnectedSignalEmittedAfterADisconnection_Test();
+    void sendframeSendsTheFrame_Test();
+    void receivedReceivesAFrame_Test();
+    void stateIsUnconnectedStateBeforeAnyConnectionMade_Test();
+    void stateIsConnectingStateAfterToldToConnectButNotYetConnected_Test();
+    void stateIsConnectedStateAfterConnectionHasBeenMade_Test();
+    void stateIsUnconnectedStateAfterGivenDisconnect_Test();
+    void autoReconnectDefaultsToFalse_Test();
+    void autoReconnectTrueAfterSetAutoReconnectTrue_Test();
+    void willNotAutoReconnectIfAutoReconnectIsSetFalse_Test();
+    void willAutoReconnectIfAutoReconnectIsSetTrue_Test();
+};
+
+NetworkTests::NetworkTests()
+    : _uut(NULL)
+{
+}
+
+NetworkTests::~NetworkTests()
+{
+}
+
+void NetworkTests::init()
+{
+    _uut.reset(new QMQTT::Network);
+}
+
+void NetworkTests::cleanup()
+{
+    _uut.reset();
+}
+
+QByteArray NetworkTests::serializeFrame(QMQTT::Frame& frame) const
+{
+    QByteArray bytes;
+    QBuffer buffer(&bytes);
+    buffer.open(QIODevice::WriteOnly);
+    QDataStream out(&buffer);
+    frame.write(out);
+    return bytes;
+}
+
+void NetworkTests::flushEvents()
+{
+    while (QCoreApplication::hasPendingEvents())
+    {
+        QCoreApplication::processEvents(QEventLoop::AllEvents);
+        QCoreApplication::sendPostedEvents(0, QEvent::DeferredDelete);
+    }
+}
+
+void NetworkTests::defaultConstructor_Test()
+{
+    QCOMPARE(_uut->isConnected(), false);
+    QCOMPARE(_uut->autoReconnect(), false);
+    QCOMPARE(_uut->state(), QAbstractSocket::UnconnectedState);
+}
+
+void NetworkTests::connectToMakesTCPConnection_Test()
+{
+    TcpServer server;
+    _uut->connectTo(server.serverAddress().toString(), server.serverPort());
+    bool timedOut = false;
+    bool connectionMade = server.waitForNewConnection(5000, &timedOut);
+
+    QCOMPARE(connectionMade, true);
+    QCOMPARE(timedOut, false);
+}
+
+void NetworkTests::connectedSignalEmittedAfterConnectionMade_Test()
+{
+    TcpServer server;
+    QSignalSpy spy(_uut.data(), &QMQTT::Network::connected);
+    _uut->connectTo(server.serverAddress().toString(), server.serverPort());
+    QCOMPARE(spy.count(), 0);
+
+    flushEvents();
+    QCOMPARE(spy.count(), 1);
+}
+
+void NetworkTests::isConnectedTrueWhenInConnectedState_Test()
+{
+    TcpServer server;
+    _uut->connectTo(server.serverAddress().toString(), server.serverPort());
+    flushEvents();
+
+    QCOMPARE(_uut->isConnected(), true);
+}
+
+void NetworkTests::isConnectedFalseWhenNotInConnectedState_Test()
+{
+    QCOMPARE(_uut->isConnected(), false);
+}
+
+void NetworkTests::disconnectWillDisconnectASocketConnection_Test()
+{
+    TcpServer server;
+    _uut->connectTo(server.serverAddress().toString(), server.serverPort());
+    flushEvents();
+    QCOMPARE(_uut->isConnected(), true);
+
+    _uut->disconnect();
+    flushEvents();
+
+    QCOMPARE(_uut->isConnected(), false);
+}
+
+void NetworkTests::disconnectedSignalEmittedAfterADisconnection_Test()
+{
+    TcpServer server;
+    _uut->connectTo(server.serverAddress().toString(), server.serverPort());
+    flushEvents();
+    QCOMPARE(_uut->isConnected(), true);
+
+    QSignalSpy spy(_uut.data(), &QMQTT::Network::disconnected);
+    QCOMPARE(spy.count(), 0);
+
+    _uut->disconnect();
+    flushEvents();
+
+    QCOMPARE(spy.count(), 1);
+}
+
+void NetworkTests::sendframeSendsTheFrame_Test()
+{
+    TcpServer server;
+    _uut->connectTo(server.serverAddress().toString(), server.serverPort());
+    flushEvents();
+    QCOMPARE(_uut->isConnected(), true);
+
+    QByteArray data("abc");
+    QMQTT::Frame frame(42, data);
+    _uut->sendFrame(frame);
+    flushEvents();
+
+    QCOMPARE(server.data(), serializeFrame(frame));
+}
+
+void NetworkTests::receivedReceivesAFrame_Test()
+{
+    TcpServer server;
+    _uut->connectTo(server.serverAddress().toString(), server.serverPort());
+    flushEvents();
+    QCOMPARE(_uut->isConnected(), true);
+
+    qRegisterMetaType<QMQTT::Frame>("QMQTT::Frame");
+    QSignalSpy spy(_uut.data(), &QMQTT::Network::received);
+
+    QByteArray data("abc");
+    QMQTT::Frame frameSent(42, data);
+    QByteArray bytesSent = serializeFrame(frameSent);
+    server.socket()->write(bytesSent);
+
+    flushEvents();
+
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.at(0).at(0).value<QMQTT::Frame>(), frameSent);
+}
+
+void NetworkTests::stateIsUnconnectedStateBeforeAnyConnectionMade_Test()
+{
+    QCOMPARE(_uut->state(), QAbstractSocket::UnconnectedState);
+}
+
+void NetworkTests::stateIsConnectingStateAfterToldToConnectButNotYetConnected_Test()
+{
+    TcpServer server;
+    _uut->connectTo(server.serverAddress().toString(), server.serverPort());
+    QCOMPARE(_uut->state(), QAbstractSocket::ConnectingState);
+}
+
+void NetworkTests::stateIsConnectedStateAfterConnectionHasBeenMade_Test()
+{
+    TcpServer server;
+    _uut->connectTo(server.serverAddress().toString(), server.serverPort());
+    flushEvents();
+    QCOMPARE(_uut->state(), QAbstractSocket::ConnectedState);
+}
+
+void NetworkTests::stateIsUnconnectedStateAfterGivenDisconnect_Test()
+{
+    TcpServer server;
+    _uut->connectTo(server.serverAddress().toString(), server.serverPort());
+    flushEvents();
+    QCOMPARE(_uut->state(), QAbstractSocket::ConnectedState);
+
+    _uut->disconnect();
+    QCOMPARE(_uut->state(), QAbstractSocket::UnconnectedState);
+}
+
+void NetworkTests::autoReconnectDefaultsToFalse_Test()
+{
+    QCOMPARE(_uut->autoReconnect(), false);
+}
+
+void NetworkTests::autoReconnectTrueAfterSetAutoReconnectTrue_Test()
+{
+    _uut->setAutoReconnect(true);
+    QCOMPARE(_uut->autoReconnect(), true);
+}
+
+void NetworkTests::willNotAutoReconnectIfAutoReconnectIsSetFalse_Test()
+{
+    TcpServer server;
+    _uut->connectTo(server.serverAddress().toString(), server.serverPort());
+    flushEvents();
+    QCOMPARE(_uut->isConnected(), true);
+
+    server.socket()->disconnectFromHost();
+    server.socket()->waitForDisconnected(5000);
+    flushEvents();
+
+    QCOMPARE(_uut->isConnected(), false);
+}
+
+void NetworkTests::willAutoReconnectIfAutoReconnectIsSetTrue_Test()
+{
+    QSKIP("Autoreconnect feature not yet enabled");
+
+    _uut->setAutoReconnect(true);
+
+    TcpServer server;
+    _uut->connectTo(server.serverAddress().toString(), server.serverPort());
+    flushEvents();
+    QCOMPARE(_uut->isConnected(), true);
+
+    server.socket()->disconnectFromHost();
+    server.socket()->waitForDisconnected(5000);
+    flushEvents();
+
+    QCOMPARE(_uut->autoReconnect(), true);
+    QCOMPARE(_uut->isConnected(), true);
+}
+
+QTEST_MAIN(NetworkTests);
+#include "networktests.moc"

--- a/tests/networktests.pro
+++ b/tests/networktests.pro
@@ -1,0 +1,9 @@
+QT += widgets testlib network
+QT -= gui
+TARGET = networktests
+DEFINES += QMQTT_LIBRARY_TESTS
+CONFIG += testcase
+SOURCES += tcpserver.cpp networktests.cpp
+HEADERS += tcpserver.h
+INCLUDEPATH += ..
+LIBS += -L.. -lqmqtt

--- a/tests/routedmessagetests.cpp
+++ b/tests/routedmessagetests.cpp
@@ -1,0 +1,48 @@
+#include <qmqtt_routedmessage.h>
+#include <QTest>
+#include <QScopedPointer>
+
+class RoutedMessageTests : public QObject
+{
+    Q_OBJECT
+public:
+    explicit RoutedMessageTests();
+    virtual ~RoutedMessageTests();
+
+    QScopedPointer<QMQTT::RoutedMessage> _uut;
+
+private slots:
+    void init();
+    void cleanup();
+
+    void constructor_Test();
+};
+
+RoutedMessageTests::RoutedMessageTests()
+    : _uut(NULL)
+{
+}
+
+RoutedMessageTests::~RoutedMessageTests()
+{
+}
+
+void RoutedMessageTests::init()
+{
+    _uut.reset(new QMQTT::RoutedMessage(QMQTT::Message()));
+}
+
+void RoutedMessageTests::cleanup()
+{
+    _uut.reset();
+}
+
+void RoutedMessageTests::constructor_Test()
+{
+    QCOMPARE(_uut->message(), QMQTT::Message());
+    QHash<QString, QString> emptyHash;
+    QCOMPARE(_uut->parameters(), emptyHash);
+}
+
+QTEST_MAIN(RoutedMessageTests);
+#include "routedmessagetests.moc"

--- a/tests/routedmessagetests.pro
+++ b/tests/routedmessagetests.pro
@@ -1,0 +1,8 @@
+QT += widgets testlib
+QT -= gui
+TARGET = routedmessagetests
+DEFINES += QMQTT_LIBRARY_TESTS
+CONFIG += testcase
+SOURCES += routedmessagetests.cpp
+INCLUDEPATH += ..
+LIBS += -L.. -lqmqtt

--- a/tests/routertests.cpp
+++ b/tests/routertests.cpp
@@ -1,0 +1,56 @@
+#include <qmqtt_router.h>
+#include <qmqtt_client.h>
+#include <qmqtt_routesubscription.h>
+#include <QTest>
+#include <QSignalSpy>
+#include <QScopedPointer>
+
+class RouterTests : public QObject
+{
+    Q_OBJECT
+public:
+    explicit RouterTests();
+    virtual ~RouterTests();
+
+    QScopedPointer<QMQTT::Client> _client;
+    QScopedPointer<QMQTT::Router> _uut;
+
+private slots:
+    void init();
+    void cleanup();
+
+    void subscribe_Test();
+};
+
+RouterTests::RouterTests()
+    : _uut(NULL)
+{
+}
+
+RouterTests::~RouterTests()
+{
+}
+
+void RouterTests::init()
+{
+    _client.reset(new QMQTT::Client);
+    _uut.reset(new QMQTT::Router(_client.data()));
+}
+
+void RouterTests::cleanup()
+{
+    _uut.reset();
+    _client.reset();
+}
+
+void RouterTests::subscribe_Test()
+{
+    QMQTT::RouteSubscription* subscription = _uut->subscribe("route");
+    QVERIFY(NULL != subscription);
+    QCOMPARE(subscription->route(), QString("route"));
+}
+
+// todo: need to figure out how to test subscribe a little better
+
+QTEST_MAIN(RouterTests);
+#include "routertests.moc"

--- a/tests/routertests.pro
+++ b/tests/routertests.pro
@@ -1,0 +1,9 @@
+QT += widgets testlib network
+QT -= gui
+TARGET = routertests
+DEFINES += QMQTT_LIBRARY_TESTS
+CONFIG += testcase
+SOURCES += tcpserver.cpp routertests.cpp
+HEADERS += tcpserver.h
+INCLUDEPATH += ..
+LIBS += -L.. -lqmqtt

--- a/tests/routesubscriptiontests.cpp
+++ b/tests/routesubscriptiontests.cpp
@@ -1,0 +1,41 @@
+#include <qmqtt_routesubscription.h>
+#include <QTest>
+#include <QScopedPointer>
+
+class RouteSubscriptionTests : public QObject
+{
+    Q_OBJECT
+public:
+    explicit RouteSubscriptionTests();
+    virtual ~RouteSubscriptionTests();
+
+    QScopedPointer<QMQTT::RouteSubscription> _uut;
+
+private slots:
+    void init();
+    void cleanup();
+
+    // todo: can't really test directly here, only Route class can insantiate for now
+};
+
+RouteSubscriptionTests::RouteSubscriptionTests()
+    : _uut(NULL)
+{
+}
+
+RouteSubscriptionTests::~RouteSubscriptionTests()
+{
+}
+
+void RouteSubscriptionTests::init()
+{
+    _uut.reset();
+}
+
+void RouteSubscriptionTests::cleanup()
+{
+    _uut.reset();
+}
+
+QTEST_MAIN(RouteSubscriptionTests);
+#include "routesubscriptiontests.moc"

--- a/tests/routesubscriptiontests.pro
+++ b/tests/routesubscriptiontests.pro
@@ -1,0 +1,8 @@
+QT += widgets testlib
+QT -= gui
+TARGET = routesubscriptiontests
+DEFINES += QMQTT_LIBRARY_TESTS
+CONFIG += testcase
+SOURCES += routesubscriptiontests.cpp
+INCLUDEPATH += ..
+LIBS += -L.. -lqmqtt

--- a/tests/tcpserver.cpp
+++ b/tests/tcpserver.cpp
@@ -1,0 +1,49 @@
+#include "tcpserver.h"
+#include <QHostAddress>
+#include <QTcpSocket>
+
+const QHostAddress TcpServer::HOST = QHostAddress::LocalHost;
+const quint16 TcpServer::PORT = 3875;
+
+TcpServer::TcpServer()
+    : _socket(NULL)
+{
+    connect(this, &QTcpServer::newConnection, this, &TcpServer::on_newConnection);
+    listen(HOST, PORT);
+}
+
+TcpServer::~TcpServer()
+{
+}
+
+void TcpServer::on_newConnection()
+{
+    if(NULL != _socket)
+    {
+        disconnect(_socket, &QTcpSocket::readyRead, this, &TcpServer::on_readyRead);
+        _socket->disconnectFromHost();
+        _socket->deleteLater();
+        _socket = NULL;
+        _data.clear();
+    }
+    _socket = nextPendingConnection();
+    if(NULL != _socket)
+    {
+        connect(_socket, &QTcpSocket::readyRead, this, &TcpServer::on_readyRead);
+    }
+}
+
+void TcpServer::on_readyRead()
+{
+    _data.append(_socket->readAll());
+}
+
+QByteArray TcpServer::data() const
+{
+    return _data;
+}
+
+QTcpSocket* TcpServer::socket() const
+{
+    return _socket;
+}

--- a/tests/tcpserver.h
+++ b/tests/tcpserver.h
@@ -1,0 +1,29 @@
+#ifndef TCP_SERVER_H
+#define TCP_SERVER_H
+
+#include <QTcpServer>
+#include <QHostAddress>
+
+class TcpServer : public QTcpServer
+{
+    Q_OBJECT
+public:
+    TcpServer();
+    virtual ~TcpServer();
+
+    QByteArray data() const;
+    QTcpSocket* socket() const;
+
+    static const QHostAddress HOST;
+    static const quint16 PORT;
+
+protected:
+    QTcpSocket* _socket;
+    QByteArray _data;
+
+protected slots:
+    void on_newConnection();
+    void on_readyRead();
+};
+
+#endif // TCP_SERVER_H

--- a/tests/testmain.cpp
+++ b/tests/testmain.cpp
@@ -1,0 +1,66 @@
+#include "willtests.h"
+#include "messagetests.h"
+#include "frametests.h"
+#include "networktests.h"
+#include "routedmessagetests.h"
+#include "routertests.h"
+#include "routesubscriptiontests.h"
+#include "clienttests.h"
+#include <QtTest>
+
+class TestRunner
+{
+public:
+    TestRunner(int argc = 0, char** argv = NULL)
+        : _argc(argc)
+        , _argv(argv)
+        , _exitCode(0)
+    {
+    }
+
+    void exec(QObject* testObject)
+    {
+        int ec = QTest::qExec(testObject, _argc, _argv);
+        if (_exitCode == 0)
+        {
+            _exitCode = ec;
+        }
+    }
+
+    int _argc;
+    char** _argv;
+    int _exitCode;
+};
+
+int main(int argc, char *argv[])
+{    
+    QApplication app(argc, argv);
+
+    TestRunner runner(argc, argv);
+
+//    WillTests willTests;
+//    runner.exec(&willTests);
+
+//    MessageTests messageTests;
+//    runner.exec(&messageTests);
+
+//    FrameTests frameTests;
+//    runner.exec(&frameTests);
+
+//    NetworkTests networkTests;
+//    runner.exec(&networkTests);
+
+//    RoutedMessageTests routedMessageTests;
+//    runner.exec(&routedMessageTests);
+
+//    RouterTests routerTests;
+//    runner.exec(&routerTests);
+
+//    RouteSubscriptionTests routeSubscriptionTests;
+//    runner.exec(&routeSubscriptionTests);
+
+    ClientTests clientTests;
+    runner.exec(&clientTests);
+
+    return runner._exitCode;
+}

--- a/tests/tests.pri
+++ b/tests/tests.pri
@@ -1,0 +1,19 @@
+OTHER_FILES += \
+    $${TEST_FILES} \
+    tests/tests.pri
+
+unix {
+    unit_tests_directory = tests
+    unit_tests.target = all
+    unit_tests.commands = \
+        mkdir -p $${OUT_PWD}/$${unit_tests_directory}; \
+        cd $${OUT_PWD}/$${unit_tests_directory}; \
+        for pro_path in $$find(TEST_FILES,\.pro$); do \
+            pro_filename=\$\${pro_path$${LITERAL_HASH}$${LITERAL_HASH}*/}; \
+            pro_basename=\$\${pro_filename%.pro}; \
+            $${QMAKE_QMAKE} -o Makefile.\$\${pro_basename} $${PWD}/\$\${pro_filename}; \
+            LD_LIBRARY_PATH=$${OUT_PWD} make -f Makefile.\$\${pro_basename} check; \
+        done; \
+        cd $${OUT_PWD}
+    QMAKE_EXTRA_TARGETS += unit_tests
+}

--- a/tests/willtests.cpp
+++ b/tests/willtests.cpp
@@ -1,0 +1,82 @@
+#include <qmqtt_will.h>
+#include <QTest>
+#include <QScopedPointer>
+
+class WillTests : public QObject
+{
+    Q_OBJECT
+public:
+    explicit WillTests();
+    virtual ~WillTests();
+
+    QScopedPointer<QMQTT::Will> _uut;
+
+private slots:
+    void init();
+    void cleanup();
+
+    void qosDefaultsToZero_Test();
+    void qosSettableToFive_Test();
+
+    void retainDefaultsToFalse_Test();
+    void retainSettableToTrue_Test();
+
+    void topicSettableToAString_Test();
+    void messageSettableToAString_Test();
+};
+
+WillTests::WillTests()
+    : _uut(NULL)
+{
+}
+
+WillTests::~WillTests()
+{
+}
+
+void WillTests::init()
+{
+    _uut.reset(new QMQTT::Will("", ""));
+}
+
+void WillTests::cleanup()
+{
+    _uut.reset();
+}
+
+void WillTests::qosDefaultsToZero_Test()
+{
+    QCOMPARE(_uut->qos(), static_cast<quint8>(0));
+}
+
+void WillTests::qosSettableToFive_Test()
+{
+    _uut->setQos(5);
+    QCOMPARE(_uut->qos(), static_cast<quint8>(5));
+}
+
+void WillTests::retainDefaultsToFalse_Test()
+{
+    QCOMPARE(_uut->retain(), false);
+}
+
+void WillTests::retainSettableToTrue_Test()
+{
+    _uut->setRetain(true);
+    QCOMPARE(_uut->retain(), true);
+}
+
+void WillTests::topicSettableToAString_Test()
+{
+    _uut->setTopic(QString("topic"));
+    QCOMPARE(_uut->topic(), QString("topic"));
+}
+
+void WillTests::messageSettableToAString_Test()
+{
+    _uut->setMessage(QString("message"));
+    QCOMPARE(_uut->message(), QString("message"));
+}
+
+QTEST_MAIN(WillTests);
+#include "willtests.moc"

--- a/tests/willtests.pro
+++ b/tests/willtests.pro
@@ -1,0 +1,8 @@
+QT += widgets testlib
+QT -= gui
+DEFINES += QMQTT_LIBRARY_TESTS
+TARGET = willtests
+CONFIG += testcase
+SOURCES += willtests.cpp
+INCLUDEPATH += ..
+LIBS += -L.. -lqmqtt


### PR DESCRIPTION
I am adding some tests so I can make further changes going forward.
I had to change the existing production code a bit to get the tests in.

* Signals should generally not have parameters passed by reference, the recipient could easily be on another thread. Even if not, then is one really going to make a change that is intended to modify the originating memory location?
* Signals should also fully specify the full class scope. The recipient is unlikely to have the correct namespace exposed.

These two changes eliminate quite of a few of the signal slot errors.
I plan on making a lot of contributions going forward. Qt is my thing, but I follow TDD practices.