### PR TITLE
Consistently use signal const reference params

### DIFF
--- a/qmqtt_client.cpp
+++ b/qmqtt_client.cpp
@@ -247,8 +247,9 @@ void Client::onDisconnected()
 
 //---------------------------------------------
 //---------------------------------------------
-void Client::onReceived(QMQTT::Frame frame)
+void Client::onReceived(const QMQTT::Frame& frm)
 {
+    QMQTT::Frame frame(frm);
     quint8 qos = 0;
     bool retain, dup;
     QString topic;
@@ -303,13 +304,13 @@ void Client::onReceived(QMQTT::Frame frame)
     }
 }
 
-void Client::handleConnack(quint8 ack)
+void Client::handleConnack(const quint8 ack)
 {
     qCDebug(client) << "connack: " << ack;
     emit connacked(ack);
 }
 
-void Client::handlePublish(Message & message)
+void Client::handlePublish(const Message& message)
 {
     Q_D(Client);
     if(message.qos() == MQTT_QOS1) {
@@ -320,7 +321,7 @@ void Client::handlePublish(Message & message)
     emit received(message);
 }
 
-void Client::handlePuback(quint8 type, quint16 msgid)
+void Client::handlePuback(const quint8 type, const quint16 msgid)
 {
     Q_D(Client);
     if(type == PUBREC) {

--- a/qmqtt_client.h
+++ b/qmqtt_client.h
@@ -141,19 +141,19 @@ public slots:
 
 signals:
     void connected();
-    void error(QAbstractSocket::SocketError);
-    void connacked(quint8 ack);
+    void error(const QAbstractSocket::SocketError socketError);
+    void connacked(const quint8 ack);
     //send PUBLISH and receive PUBACK
-    void published(QMQTT::Message message);
-    void pubacked(quint8 type, quint16 msgid);
+    void published(const QMQTT::Message& message);
+    void pubacked(const quint8 type, const quint16 msgid);
     //receive PUBLISH
-    void received(const QMQTT::Message message);
+    void received(const QMQTT::Message& message);
     //send SUBSCRIBE and receive SUBACKED
-    void subscribed(const QString topic);
-    void subacked(quint16 mid, quint8 qos);
+    void subscribed(const QString& topic);
+    void subacked(const quint16 mid, const quint8 qos);
     //send UNSUBSCRIBE and receive UNSUBACKED
-    void unsubscribed(const QString topic);
-    void unsubacked(quint16 mid);
+    void unsubscribed(const QString& topic);
+    void unsubacked(const quint16 mid);
     //receive PINGRESP
     void pong();
     void disconnected();
@@ -161,10 +161,10 @@ signals:
 private slots:
     void onConnected();
     void onDisconnected();
-    void onReceived(QMQTT::Frame frame);
-    void handlePublish(Message &message);
-    void handleConnack(quint8 ack);
-    void handlePuback(quint8 type, quint16 msgid);
+    void onReceived(const QMQTT::Frame& frame);
+    void handlePublish(const Message& message);
+    void handleConnack(const quint8 ack);
+    void handlePuback(const quint8 type, const quint16 msgid);
 
 private:
     ClientPrivate *const  d_ptr;

--- a/qmqtt_client_p.cpp
+++ b/qmqtt_client_p.cpp
@@ -66,7 +66,7 @@ void ClientPrivate::init(QObject * parent)
     QObject::connect(network, SIGNAL(connected()), q, SLOT(onConnected()));
     QObject::connect(network, SIGNAL(error(QAbstractSocket::SocketError)), q, SIGNAL(error(QAbstractSocket::SocketError)));
     QObject::connect(network, SIGNAL(disconnected()), q, SLOT(onDisconnected()));
-    QObject::connect(network, SIGNAL(received(QMQTT::Frame)), q, SLOT(onReceived(QMQTT::Frame)));
+    QObject::connect(network, SIGNAL(received(const QMQTT::Frame&)), q, SLOT(onReceived(const QMQTT::Frame&)));
 }
 
 void ClientPrivate::init(const QString host, int port, QObject * parent)

--- a/qmqtt_message.cpp
+++ b/qmqtt_message.cpp
@@ -68,7 +68,7 @@ bool Message::operator==(const Message& other) const
       && _dup == other._dup;
 }
 
-quint16 Message::id()
+quint16 Message::id() const
 {
     return _id;
 }
@@ -88,7 +88,7 @@ void Message::setQos(quint8 qos)
     _qos = qos;
 }
 
-bool Message::retain()
+bool Message::retain() const
 {
     return _retain;
 }
@@ -98,7 +98,7 @@ void Message::setRetain(bool retain)
     _retain = retain;
 }
 
-bool Message::dup()
+bool Message::dup() const
 {
     return _dup;
 }

--- a/qmqtt_message.h
+++ b/qmqtt_message.h
@@ -48,16 +48,16 @@ public:
 
     bool operator==(const Message& other) const;
 
-    quint16 id();
+    quint16 id() const;
     void setId(quint16 id);
 
     quint8 qos() const;
     void setQos(quint8 qos);
 
-    bool retain();
+    bool retain() const;
     void setRetain(bool retain);
 
-    bool dup();
+    bool dup() const;
     void setDup(bool dup);
 
     QString topic() const;

--- a/qmqtt_network.h
+++ b/qmqtt_network.h
@@ -63,8 +63,8 @@ public:
 signals:
     void connected();
     void disconnected();
-    void error(QAbstractSocket::SocketError);
-    void received(QMQTT::Frame frame);
+    void error(const QAbstractSocket::SocketError socketError);
+    void received(const QMQTT::Frame& frame);
 
 public slots:
     void connectTo(const QString & host, quint32 port);

--- a/tests/clienttests.cpp
+++ b/tests/clienttests.cpp
@@ -667,7 +667,7 @@ void ClientTests::publishEmitsPublishedSignal_Test()
     server->waitForNewConnection(5000);
     flushEvents();
 
-    qRegisterMetaType<QMQTT::Message>("QMQTT::Message");
+    qRegisterMetaType<QMQTT::Message>("QMQTT::Message&");
     QSignalSpy spy(_uut.data(), &QMQTT::Client::published);
 
     QByteArray payload("payload");
@@ -848,7 +848,8 @@ void ClientTests::tcpSocketDisconnectEmitsDisconnectedSignal_Test()
     QSignalSpy spy(_uut.data(), &QMQTT::Client::disconnected);
 
     server->socket()->disconnectFromHost();
-    server->socket()->waitForDisconnected(5000);
+    server->socket()->state() == QAbstractSocket::UnconnectedState
+       || server->socket()->waitForDisconnected(5000);
     flushEvents();
 
     QCOMPARE(spy.count(), 1);

--- a/tests/networktests.cpp
+++ b/tests/networktests.cpp
@@ -239,7 +239,8 @@ void NetworkTests::willNotAutoReconnectIfAutoReconnectIsSetFalse_Test()
     QCOMPARE(_uut->isConnected(), true);
 
     server.socket()->disconnectFromHost();
-    server.socket()->waitForDisconnected(5000);
+    server.socket()->state() == QAbstractSocket::UnconnectedState
+       || server.socket()->waitForDisconnected(5000);
     flushEvents();
 
     QCOMPARE(_uut->isConnected(), false);


### PR DESCRIPTION
Based on my previous reading, the const reference passing is both preferred for memory efficiency and also the standard with Qt itself. So, this moves our signals back.

* Make signals use const parameters when primitives and const-by-reference with custom classes.
* Make a few function calls take const parameters
* Cleaned up a socket warning  with waitForDisconnect()