### PR TITLE
Implement autoreconnect

### DIFF
--- a/qmqtt.pro
+++ b/qmqtt.pro
@@ -5,7 +5,7 @@ src.file = src/qmqtt.pro
 
 example.depends = src
 
-unix {
+unix:!NO_UNIT_TESTS: {
     SUBDIRS += gtest tests
     tests.depends = gtest src
 }

--- a/src/qmqtt.pro
+++ b/src/qmqtt.pro
@@ -16,7 +16,8 @@ SOURCES += qmqtt_client.cpp \
     qmqtt_routesubscription.cpp \
     qmqtt_routedmessage.cpp \
     qmqtt_message_p.cpp \
-    qmqtt_socket.cpp
+    qmqtt_socket.cpp \
+    qmqtt_timer.cpp
 
 HEADERS += qmqtt_client.h\
     qmqtt_global.h \
@@ -31,7 +32,9 @@ HEADERS += qmqtt_client.h\
     qmqtt_networkinterface.h \
     qmqtt_message_p.h \
     qmqtt_socketinterface.h \
-    qmqtt_socket.h
+    qmqtt_socket.h \
+    qmqtt_timer.h \
+    qmqtt_timerinterface.h
 
 isEmpty(PREFIX) {
     contains(MEEGO_EDITION,harmattan) {

--- a/src/qmqtt_network.h
+++ b/src/qmqtt_network.h
@@ -61,10 +61,15 @@ public:
     bool autoReconnect() const;
     void setAutoReconnect(const bool autoReconnect);
     QAbstractSocket::SocketState state() const;
+    int autoReconnectInterval() const;
+    void setAutoReonnectInterval(const int autoReconnectInterval);
 
 public slots:
     void connectToHost(const QHostAddress& host, const quint16 port);
     void disconnectFromHost();
+
+protected slots:
+    void onSocketError(QAbstractSocket::SocketError socketError);
 
 protected:
     void initialize();
@@ -74,6 +79,7 @@ protected:
     QHostAddress _host;
     QBuffer _buffer;
     bool _autoReconnect;
+    int _autoReconnectInterval;
     SocketInterface* _socket;
     TimerInterface* _autoReconnectTimer;
 

--- a/src/qmqtt_network.h
+++ b/src/qmqtt_network.h
@@ -44,6 +44,7 @@
 namespace QMQTT {
 
 class SocketInterface;
+class TimerInterface;
 
 class Network : public NetworkInterface
 {
@@ -51,7 +52,8 @@ class Network : public NetworkInterface
 
 public:
     Network(QObject* parent = NULL);
-    Network(SocketInterface* socketInterface, QObject* parent = NULL);
+    Network(SocketInterface* socketInterface, TimerInterface* timerInterface,
+            QObject* parent = NULL);
     ~Network();
 
     void sendFrame(Frame& frame);
@@ -70,12 +72,15 @@ protected:
 
     quint16 _port;
     QHostAddress _host;
-    SocketInterface* _socket;
     QBuffer _buffer;
     bool _autoReconnect;
+    SocketInterface* _socket;
+    TimerInterface* _autoReconnectTimer;
 
 protected slots:
     void onSocketReadReady();
+    void onDisconnected();
+    void connectToHost();
 
 private:
     Q_DISABLE_COPY(Network)

--- a/src/qmqtt_networkinterface.h
+++ b/src/qmqtt_networkinterface.h
@@ -60,6 +60,7 @@ signals:
     void connected();
     void disconnected();
     void received(const QMQTT::Frame& frame);
+    void error(QAbstractSocket::SocketError error);
 };
 
 } // namespace QMQTT

--- a/src/qmqtt_socket.cpp
+++ b/src/qmqtt_socket.cpp
@@ -70,7 +70,6 @@ bool QMQTT::Socket::atEnd() const
     return _socket->atEnd();
 }
 
-
 bool QMQTT::Socket::waitForBytesWritten(int msecs)
 {
     return _socket->waitForBytesWritten(msecs);
@@ -86,7 +85,6 @@ QAbstractSocket::SocketError QMQTT::Socket::error() const
     return _socket->error();
 }
 
-// QIODevice demands
 qint64 QMQTT::Socket::readData(char* data, qint64 maxlen)
 {
     return _socket->read(data, maxlen);

--- a/src/qmqtt_timer.cpp
+++ b/src/qmqtt_timer.cpp
@@ -1,5 +1,5 @@
 /*
- * qmqtt_socketinterface.h - qmqtt socket interface header
+ * qmqtt_timer.cpp - qmqtt timer
  *
  * Copyright (c) 2013  Ery Lee <ery.lee at gmail dot com>
  * All rights reserved.
@@ -29,41 +29,44 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  */
-#ifndef QMQTT_SOCKET_INTERFACE_H
-#define QMQTT_SOCKET_INTERFACE_H
+#include "qmqtt_timer.h"
 
-#include <QHostAddress>
-#include <QIODevice>
-
-namespace QMQTT
+QMQTT::Timer::Timer(QObject* parent)
+    : TimerInterface(parent)
 {
-
-class SocketInterface : public QIODevice
-{
-    Q_OBJECT
-public:
-    explicit SocketInterface(QObject* parent = NULL) : QIODevice(parent)
-    {
-        setOpenMode(QIODevice::ReadWrite);
-    }
-    virtual	~SocketInterface() {}
-
-    virtual void connectToHost(const QHostAddress& address, quint16 port) = 0;
-    virtual void disconnectFromHost() = 0;
-    virtual QAbstractSocket::SocketState state() const = 0;
-    virtual bool atEnd() const = 0;
-    virtual bool waitForBytesWritten(int msecs) = 0;
-    virtual QAbstractSocket::SocketError error() const = 0;
-    virtual qint64 readData(char* data, qint64 maxlen) = 0;
-    virtual qint64 writeData(const char* data, qint64 len) = 0;
-
-signals:
-    void connected();
-    void disconnected();
-    void readyRead();
-    void error(QAbstractSocket::SocketError socketError);
-};
-
+    connect(&_timer, &QTimer::timeout, this, &TimerInterface::timeout);
 }
 
-#endif // QMQTT_SOCKET_INTERFACE_H
+QMQTT::Timer::~Timer()
+{
+}
+
+bool QMQTT::Timer::isSingleShot() const
+{
+    return _timer.isSingleShot();
+}
+
+void QMQTT::Timer::setSingleShot(bool singleShot)
+{
+    _timer.setSingleShot(singleShot);
+}
+
+int QMQTT::Timer::interval() const
+{
+    return _timer.interval();
+}
+
+void QMQTT::Timer::setInterval(int msec)
+{
+    _timer.setInterval(msec);
+}
+
+void QMQTT::Timer::start()
+{
+    _timer.start();
+}
+
+void QMQTT::Timer::stop()
+{
+    _timer.stop();
+}

--- a/src/qmqtt_timer.h
+++ b/src/qmqtt_timer.h
@@ -1,5 +1,5 @@
 /*
- * qmqtt_socketinterface.h - qmqtt socket interface header
+ * qmqtt_timer.h - qmqtt timer header
  *
  * Copyright (c) 2013  Ery Lee <ery.lee at gmail dot com>
  * All rights reserved.
@@ -29,41 +29,32 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  */
-#ifndef QMQTT_SOCKET_INTERFACE_H
-#define QMQTT_SOCKET_INTERFACE_H
+#ifndef QMQTT_TIMER_H
+#define QMQTT_TIMER_H
 
-#include <QHostAddress>
-#include <QIODevice>
+#include "qmqtt_timerinterface.h"
+#include <QTimer>
 
-namespace QMQTT
-{
+namespace QMQTT {
 
-class SocketInterface : public QIODevice
+class Timer : public TimerInterface
 {
     Q_OBJECT
 public:
-    explicit SocketInterface(QObject* parent = NULL) : QIODevice(parent)
-    {
-        setOpenMode(QIODevice::ReadWrite);
-    }
-    virtual	~SocketInterface() {}
+    explicit Timer(QObject *parent = 0);
+    virtual ~Timer();
 
-    virtual void connectToHost(const QHostAddress& address, quint16 port) = 0;
-    virtual void disconnectFromHost() = 0;
-    virtual QAbstractSocket::SocketState state() const = 0;
-    virtual bool atEnd() const = 0;
-    virtual bool waitForBytesWritten(int msecs) = 0;
-    virtual QAbstractSocket::SocketError error() const = 0;
-    virtual qint64 readData(char* data, qint64 maxlen) = 0;
-    virtual qint64 writeData(const char* data, qint64 len) = 0;
+    bool isSingleShot() const;
+    void setSingleShot(bool singleShot);
+    int interval() const;
+    void setInterval(int msec);
+    void start();
+    void stop();
 
-signals:
-    void connected();
-    void disconnected();
-    void readyRead();
-    void error(QAbstractSocket::SocketError socketError);
+protected:
+    QTimer _timer;
 };
 
 }
 
-#endif // QMQTT_SOCKET_INTERFACE_H
+#endif // QMQTT_TIMER_H

--- a/src/qmqtt_timerinterface.h
+++ b/src/qmqtt_timerinterface.h
@@ -1,5 +1,5 @@
 /*
- * qmqtt_socketinterface.h - qmqtt socket interface header
+ * qmqtt_timerinterface.h - qmqtt timer interface header
  *
  * Copyright (c) 2013  Ery Lee <ery.lee at gmail dot com>
  * All rights reserved.
@@ -29,41 +29,32 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  */
-#ifndef QMQTT_SOCKET_INTERFACE_H
-#define QMQTT_SOCKET_INTERFACE_H
+#ifndef QMQTT_TIMER_INTERFACE_H
+#define QMQTT_TIMER_INTERFACE_H
 
-#include <QHostAddress>
-#include <QIODevice>
+#include <QObject>
 
-namespace QMQTT
-{
+namespace QMQTT {
 
-class SocketInterface : public QIODevice
+class TimerInterface : public QObject
 {
     Q_OBJECT
 public:
-    explicit SocketInterface(QObject* parent = NULL) : QIODevice(parent)
-    {
-        setOpenMode(QIODevice::ReadWrite);
-    }
-    virtual	~SocketInterface() {}
+    explicit TimerInterface(QObject* parent = NULL) : QObject(parent) {}
+    virtual ~TimerInterface() {}
 
-    virtual void connectToHost(const QHostAddress& address, quint16 port) = 0;
-    virtual void disconnectFromHost() = 0;
-    virtual QAbstractSocket::SocketState state() const = 0;
-    virtual bool atEnd() const = 0;
-    virtual bool waitForBytesWritten(int msecs) = 0;
-    virtual QAbstractSocket::SocketError error() const = 0;
-    virtual qint64 readData(char* data, qint64 maxlen) = 0;
-    virtual qint64 writeData(const char* data, qint64 len) = 0;
+    virtual bool isSingleShot() const = 0;
+    virtual void setSingleShot(bool singleShot) = 0;
+    virtual int interval() const = 0;
+    virtual void setInterval(int msec) = 0;
+    virtual void start() = 0;
+    virtual void stop() = 0;
 
 signals:
-    void connected();
-    void disconnected();
-    void readyRead();
-    void error(QAbstractSocket::SocketError socketError);
+    void timeout();
 };
 
 }
 
-#endif // QMQTT_SOCKET_INTERFACE_H
+#endif // QMQTT_TIMER_INTERFACE_H
+

--- a/tests/networktest.cpp
+++ b/tests/networktest.cpp
@@ -1,4 +1,5 @@
 #include "socketmock.h"
+#include "timermock.h"
 #include <qmqtt_network.h>
 #include <QSignalSpy>
 #include <QDataStream>
@@ -14,16 +15,74 @@ const QIODevice::OpenMode OPEN_MODE = QIODevice::ReadWrite;
 class NetworkTest : public Test
 {
 public:
-    explicit NetworkTest()
-        : _socketMock(new SocketMock)
-        , _network(new QMQTT::Network(_socketMock))
-    {
-    }
+    NetworkTest() {}
     virtual ~NetworkTest() {}
 
+    void flushEvents()
+    {
+        while (QCoreApplication::hasPendingEvents())
+        {
+            QCoreApplication::processEvents(QEventLoop::AllEvents);
+            QCoreApplication::sendPostedEvents(0, QEvent::DeferredDelete);
+        }
+    }
+
+    void SetUp()
+    {
+        _byteArray.clear();
+        _socketMock = new SocketMock;
+        _timerMock = new TimerMock;
+        EXPECT_CALL(*_timerMock, setSingleShot(_)).WillRepeatedly(Return());
+        EXPECT_CALL(*_timerMock, setInterval(_)).WillRepeatedly(Return());
+        _network.reset(new QMQTT::Network(_socketMock, _timerMock));
+        Mock::VerifyAndClearExpectations(_socketMock);
+    }
+
+    void TearDown()
+    {
+        _network.reset();
+        _byteArray.clear();
+    }
+
+    qint64 readDataFromFixtureByteArray(char* data, qint64 requestedLength)
+    {
+        qint64 actualLength = qMin(requestedLength, static_cast<qint64>(_byteArray.size()));
+        if(actualLength > 0)
+        {
+            memcpy(data, _byteArray.constData(), static_cast<std::size_t>(actualLength));
+            _byteArray.remove(0, actualLength);
+        }
+        return actualLength;
+    }
+
+    bool fixtureByteArrayIsEmpty() const
+    {
+        return _byteArray.isEmpty();
+    }
+
     SocketMock* _socketMock;
+    TimerMock* _timerMock;
     QSharedPointer<QMQTT::Network> _network;
+    QByteArray _byteArray;
 };
+
+TEST(NetworkNoFixtureTest, networkConstructorSetsTimerSingleShotTrue_Test)
+{
+    SocketMock* socketMock = new SocketMock;
+    TimerMock* timerMock = new TimerMock;
+    EXPECT_CALL(*timerMock, setSingleShot(true)).WillOnce(Return());
+    EXPECT_CALL(*timerMock, setInterval(_)).WillRepeatedly(Return());
+    QMQTT::Network network(socketMock, timerMock);
+}
+
+TEST(NetworkNoFixtureTest, networkConstructorSetsTimerInterval_Test)
+{
+    SocketMock* socketMock = new SocketMock;
+    TimerMock* timerMock = new TimerMock;
+    EXPECT_CALL(*timerMock, setSingleShot(_)).WillRepeatedly(Return());
+    EXPECT_CALL(*timerMock, setInterval(5000)).WillOnce(Return());
+    QMQTT::Network network(socketMock, timerMock);
+}
 
 TEST_F(NetworkTest, networkIsConnectedReturnsFalseWhenSocketStateIsUnconnectedState_Test)
 {
@@ -49,25 +108,25 @@ TEST_F(NetworkTest, networkStateReturnsConnectedStateWhenSocketStateIsConnectedS
     EXPECT_EQ(QAbstractSocket::ConnectedState, _network->state());
 }
 
-TEST_F(NetworkTest, networkConnectToHostCallsSocketConnectToHost)
+TEST_F(NetworkTest, networkConnectToHostCallsSocketConnectToHost_Test)
 {
     EXPECT_CALL(*_socketMock, connectToHost(HOST, PORT));
     _network->connectToHost(HOST, PORT);
 }
 
-TEST_F(NetworkTest, networkDisconnectFromHostCallsSocketDisconnectFromHost)
+TEST_F(NetworkTest, networkDisconnectFromHostCallsSocketDisconnectFromHost_Test)
 {
     EXPECT_CALL(*_socketMock, disconnectFromHost());
     _network->disconnectFromHost();
 }
 
-TEST_F(NetworkTest, networkStateCallsSocketState)
+TEST_F(NetworkTest, networkStateCallsSocketState_Test)
 {
     EXPECT_CALL(*_socketMock, state()).WillOnce(Return(QAbstractSocket::ConnectedState));
     EXPECT_EQ(QAbstractSocket::ConnectedState, _network->state());
 }
 
-TEST_F(NetworkTest, networkAutoReconnectDefaultsToFalse)
+TEST_F(NetworkTest, networkAutoReconnectDefaultsToFalse_Test)
 {
     EXPECT_FALSE(_network->autoReconnect());
 }
@@ -78,7 +137,7 @@ TEST_F(NetworkTest, networkSetAutoReconnectTrueSetsAutoReconnectTrue_Test)
     EXPECT_TRUE(_network->autoReconnect());
 }
 
-TEST_F(NetworkTest, networkSendFrameWillNotSendAFrameIfNotConnected)
+TEST_F(NetworkTest, networkSendFrameWillNotSendAFrameIfNotConnected_Test)
 {
     EXPECT_CALL(*_socketMock, state()).WillOnce(Return(QAbstractSocket::UnconnectedState));
     EXPECT_CALL(*_socketMock, writeData(_, _)).Times(0);
@@ -87,7 +146,7 @@ TEST_F(NetworkTest, networkSendFrameWillNotSendAFrameIfNotConnected)
     _network->sendFrame(frame);
 }
 
-TEST_F(NetworkTest, networkSendFrameWillSendAFrameIfConnected)
+TEST_F(NetworkTest, networkSendFrameWillSendAFrameIfConnected_Test)
 {
     EXPECT_CALL(*_socketMock, state()).WillOnce(Return(QAbstractSocket::ConnectedState));
     EXPECT_CALL(*_socketMock, writeData(_, _));
@@ -96,42 +155,64 @@ TEST_F(NetworkTest, networkSendFrameWillSendAFrameIfConnected)
     _network->sendFrame(frame);
 }
 
-TEST_F(NetworkTest, networkEmitsConnectedSignalWhenSocketEmitsConnectedSignal)
+TEST_F(NetworkTest, networkEmitsConnectedSignalWhenSocketEmitsConnectedSignal_Test)
 {
     QSignalSpy spy(_network.data(), &QMQTT::Network::connected);
     emit _socketMock->connected();
     EXPECT_EQ(1, spy.count());
 }
 
-TEST_F(NetworkTest, networkEmitsDisconnectedSignalWhenSocketEmitsDisconnectedSignal)
+TEST_F(NetworkTest, networkEmitsDisconnectedSignalWhenSocketEmitsDisconnectedSignal_Test)
 {
     QSignalSpy spy(_network.data(), &QMQTT::Network::disconnected);
     emit _socketMock->disconnected();
     EXPECT_EQ(1, spy.count());
 }
 
-TEST_F(NetworkTest, networkEmitsReceivedSignalOnceAFrameIsReceived)
+TEST_F(NetworkTest, networkEmitsReceivedSignalOnceAFrameIsReceived_Test)
 {
-    QByteArray byteArray;
-    QBuffer buffer(&byteArray);
+    QByteArray payload(129, 'a');
+
+    QBuffer buffer(&_byteArray);
     buffer.open(QIODevice::WriteOnly);
 
     QDataStream out(&buffer);
     out << static_cast<quint8>(0x30); // publish header
     out << static_cast<quint8>(0x81); // remaining length most-signficant 7 bits
     out << static_cast<quint8>(0x01); // remaining Length least-significant 7 bits
-    for (int i = 0; i < 129; ++i)
-    {
-        out << static_cast<quint8>('a');
-    }
     buffer.close();
+    _byteArray += payload;
+    EXPECT_EQ(132, _byteArray.size());
 
-    EXPECT_CALL(*_socketMock, atEnd()).WillOnce(Return(true));
-    EXPECT_CALL(*_socketMock, atEnd()).WillOnce(Return(false)).RetiresOnSaturation();
+    EXPECT_CALL(*_socketMock, atEnd())
+        .WillRepeatedly(Invoke(this, &NetworkTest::fixtureByteArrayIsEmpty));
     EXPECT_CALL(*_socketMock, readData(_, _))
-        .WillOnce(DoAll(SetArgPointee<0>(*byteArray.data()), Return(0x84)));
+        .WillRepeatedly(Invoke(this, &NetworkTest::readDataFromFixtureByteArray));
 
     QSignalSpy spy(_network.data(), &QMQTT::Network::received);
     emit _socketMock->readyRead();
     EXPECT_EQ(1, spy.count());
+    EXPECT_EQ(payload, spy.at(0).at(0).value<QMQTT::Frame>().data());
+}
+
+TEST_F(NetworkTest, autoReconnectWillAttemptToReconnectOnDisconnectionIfAutoReconnectIsTrue_Test)
+{
+    EXPECT_CALL(*_timerMock, start()).WillRepeatedly(DoAll(
+        Invoke(_timerMock, &QMQTT::TimerInterface::timeout),
+        Return()));
+    _network->setAutoReconnect(true);
+
+    EXPECT_CALL(*_socketMock, connectToHost(_, _));
+    emit _socketMock->disconnected();
+}
+
+TEST_F(NetworkTest, autoReconnectWillNotAttemptToReconnectOnDisconnectionIfAutoReconnectIsFalse_Test)
+{
+    EXPECT_CALL(*_timerMock, start()).WillRepeatedly(DoAll(
+        Invoke(_timerMock, &QMQTT::TimerInterface::timeout),
+        Return()));
+    _network->setAutoReconnect(false);
+
+    EXPECT_CALL(*_socketMock, connectToHost(_, _)).Times(0);
+    emit _socketMock->disconnected();
 }

--- a/tests/networktest.cpp
+++ b/tests/networktest.cpp
@@ -18,15 +18,6 @@ public:
     NetworkTest() {}
     virtual ~NetworkTest() {}
 
-    void flushEvents()
-    {
-        while (QCoreApplication::hasPendingEvents())
-        {
-            QCoreApplication::processEvents(QEventLoop::AllEvents);
-            QCoreApplication::sendPostedEvents(0, QEvent::DeferredDelete);
-        }
-    }
-
     void SetUp()
     {
         _byteArray.clear();
@@ -66,7 +57,7 @@ public:
     QByteArray _byteArray;
 };
 
-TEST(NetworkNoFixtureTest, networkConstructorSetsTimerSingleShotTrue_Test)
+TEST(NetworkNoFixtureTest, networkConstructorSetsAutoReconnectTimerSingleShotTrue_Test)
 {
     SocketMock* socketMock = new SocketMock;
     TimerMock* timerMock = new TimerMock;
@@ -75,7 +66,7 @@ TEST(NetworkNoFixtureTest, networkConstructorSetsTimerSingleShotTrue_Test)
     QMQTT::Network network(socketMock, timerMock);
 }
 
-TEST(NetworkNoFixtureTest, networkConstructorSetsTimerInterval_Test)
+TEST(NetworkNoFixtureTest, networkConstructorSetsAutoReconnectTimerInterval_Test)
 {
     SocketMock* socketMock = new SocketMock;
     TimerMock* timerMock = new TimerMock;

--- a/tests/networktest.cpp
+++ b/tests/networktest.cpp
@@ -40,7 +40,12 @@ public:
         qint64 actualLength = qMin(requestedLength, static_cast<qint64>(_byteArray.size()));
         if(actualLength > 0)
         {
-            memcpy(data, _byteArray.constData(), static_cast<std::size_t>(actualLength));
+            QBuffer buffer(&_byteArray);
+            buffer.open(QIODevice::ReadWrite);
+            QDataStream in(&buffer);
+            in.readRawData(data, actualLength);
+            buffer.close();
+
             _byteArray.remove(0, actualLength);
         }
         return actualLength;

--- a/tests/socketmock.h
+++ b/tests/socketmock.h
@@ -7,21 +7,22 @@
 class SocketMock : public QMQTT::SocketInterface
 {
 public:
-//     MOCK_METHOD3(connectToHost, void(const QHostAddress&, quint16, QIODevice::OpenMode));
-     MOCK_METHOD2(connectToHost, void(const QHostAddress&, quint16));
-     MOCK_METHOD0(disconnectFromHost, void());
-     MOCK_CONST_METHOD0(state, QAbstractSocket::SocketState());
-     MOCK_CONST_METHOD0(atEnd, bool());
-     MOCK_METHOD1(waitForBytesWritten, bool(int));
-     MOCK_CONST_METHOD0(error, QAbstractSocket::SocketError());
+    using QMQTT::SocketInterface::error;
 
-     MOCK_METHOD2(readData, qint64(char*, qint64));
-     MOCK_METHOD2(writeData, qint64(const char *, qint64));
-     MOCK_CONST_METHOD0(openMode, QIODevice::OpenMode());
+    MOCK_METHOD2(connectToHost, void(const QHostAddress&, quint16));
+    MOCK_METHOD0(disconnectFromHost, void());
+    MOCK_CONST_METHOD0(state, QAbstractSocket::SocketState());
+    MOCK_CONST_METHOD0(atEnd, bool());
+    MOCK_METHOD1(waitForBytesWritten, bool(int));
+    MOCK_CONST_METHOD0(error, QAbstractSocket::SocketError());
 
-     MOCK_METHOD2(write, qint64(const char*, qint64));
-     MOCK_METHOD1(write, qint64(const char*));
-     MOCK_METHOD1(write, qint64(const QByteArray&));
+    MOCK_METHOD2(readData, qint64(char*, qint64));
+    MOCK_METHOD2(writeData, qint64(const char *, qint64));
+    MOCK_CONST_METHOD0(openMode, QIODevice::OpenMode());
+
+    MOCK_METHOD2(write, qint64(const char*, qint64));
+    MOCK_METHOD1(write, qint64(const char*));
+    MOCK_METHOD1(write, qint64(const QByteArray&));
 };
 
 #endif // SOCKET_MOCK_H

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -26,16 +26,18 @@ HEADERS += \
     tcpserver.h \
     customprinter.h \
     networkmock.h \
-    socketmock.h
+    socketmock.h \
+    timermock.h
 
 INCLUDEPATH += \
     ../gtest/googletest/googletest/include \
     ../gtest/googletest/googlemock/include
 LIBS += -L../gtest -lgtest
 
-unit_tests.target = all
-unit_tests.commands = \
-    LD_LIBRARY_PATH=$${OUT_PWD}/../gtest:$${OUT_PWD}/../src \
-    $${OUT_PWD}/qmqtt_tests
-QMAKE_EXTRA_TARGETS += unit_tests
-
+!NO_RUN_UNIT_TESTS: {
+    unit_tests.target = all
+    unit_tests.commands = \
+        LD_LIBRARY_PATH=$${OUT_PWD}/../gtest:$${OUT_PWD}/../src \
+        $${OUT_PWD}/qmqtt_tests
+    QMAKE_EXTRA_TARGETS += unit_tests
+}

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -17,11 +17,6 @@ SOURCES += \
     frametest.cpp \
     sockettest.cpp
 
-# to be ported to gtest or deleted
-#	routedmessagetests.cpp \
-#	routertests.cpp \
-#	routesubscriptiontests.cpp \
-
 HEADERS += \
     tcpserver.h \
     customprinter.h \
@@ -34,7 +29,7 @@ INCLUDEPATH += \
     ../gtest/googletest/googlemock/include
 LIBS += -L../gtest -lgtest
 
-!NO_RUN_UNIT_TESTS: {
+unix:!NO_UNIT_TESTS:!NO_RUN_UNIT_TESTS: {
     unit_tests.target = all
     unit_tests.commands = \
         LD_LIBRARY_PATH=$${OUT_PWD}/../gtest:$${OUT_PWD}/../src \

--- a/tests/timermock.h
+++ b/tests/timermock.h
@@ -1,0 +1,18 @@
+#ifndef TIMER_MOCK_H
+#define TIMER_MOCK_H
+
+#include <qmqtt_timerinterface.h>
+#include <gmock/gmock.h>
+
+class TimerMock : public QMQTT::TimerInterface
+{
+public:
+    MOCK_CONST_METHOD0(isSingleShot, bool());
+    MOCK_METHOD1(setSingleShot, void(bool));
+    MOCK_CONST_METHOD0(interval, int());
+    MOCK_METHOD1(setInterval, void(int));
+    MOCK_METHOD0(start, void());
+    MOCK_METHOD0(stop, void());
+};
+
+#endif // TIMER_MOCK_H


### PR DESCRIPTION
* Add compiler defines that suppress building or running of unit tests.
* Add autoreconnect functionality for both connection lost and connection failed.
* Add autoreconnect interval for user.
* Add timer mock so the tests don't actually have to wait on anything.
* And, as always, add new tests and make tests more stable.