### PR TITLE
Add autoreconnect interval setters and getters on public interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Usage
 
 	#include "qmqtt.h"
 
-	QMQTT::Client *client = new QMQTT::Client("localhost", 1883);
+        QMQTT::Client *client = new QMQTT::Client(QHostAddress::LocalHost, 1883);
 
 	client->setClientId("clientId");
 
@@ -28,9 +28,10 @@ Slots
     void setClientId(const QString& clientId);
     void setUsername(const QString& username);
     void setPassword(const QString& password);
-    void setKeepAlive(int keepAlive);
+    void setKeepAlive(const int keepAlive);
     void setCleanSession(const bool cleansess);
-    void setAutoReconnect(bool value);
+    void setAutoReconnect(const bool value);
+    void setAutoReconnectInterval(const int autoReconnectInterval);
     void setWillTopic(const QString& willTopic);
     void setWillQos(const quint8 willQos);
     void setWillRetain(const bool willRetain);

--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ Signals
 
     void connected();
     void disconnected();
-
-    // for pending MQTT protocol errors
     void error(const QMQTT::ClientError error);
 
     // todo: should emit on server suback (or is that only at specific QoS levels?)
@@ -82,5 +80,5 @@ Author
 ======
 
 Feng Lee <feng@emqtt.io>   
-wguynes <wguynes@gmail.com>   
+William Guynes <wguynes@gmail.com>
 wuming123057 <huacai123057@163.com>

--- a/src/qmqtt_client.cpp
+++ b/src/qmqtt_client.cpp
@@ -154,6 +154,18 @@ void QMQTT::Client::setAutoReconnect(const bool value)
     d->setAutoReconnect(value);
 }
 
+int QMQTT::Client::autoReconnectInterval() const
+{
+    Q_D(const Client);
+    return d->autoReconnectInterval();
+}
+
+void QMQTT::Client::setAutoReconnectInterval(const int autoReconnectInterval)
+{
+    Q_D(Client);
+    d->setAutoReconnectInterval(autoReconnectInterval);
+}
+
 QString QMQTT::Client::willTopic() const
 {
     Q_D(const Client);

--- a/src/qmqtt_client.cpp
+++ b/src/qmqtt_client.cpp
@@ -279,3 +279,9 @@ void QMQTT::Client::onNetworkDisconnected()
     Q_D(Client);
     d->onNetworkDisconnected();
 }
+
+void QMQTT::Client::onNetworkError(QAbstractSocket::SocketError error)
+{
+    Q_D(Client);
+    d->onNetworkError(error);
+}

--- a/src/qmqtt_client.h
+++ b/src/qmqtt_client.h
@@ -65,6 +65,30 @@ enum ConnectionState
 
 enum ClientError
 {
+    UnknownError = 0,
+    SocketConnectionRefusedError,
+    SocketRemoteHostClosedError,
+    SocketHostNotFoundError,
+    SocketAccessError,
+    SocketResourceError,
+    SocketTimeoutError,
+    SocketDatagramTooLargeError,
+    SocketNetworkError,
+    SocketAddressInUseError,
+    SocketAddressNotAvailableError,
+    SocketUnsupportedSocketOperationError,
+    SocketUnfinishedSocketOperationError,
+    SocketProxyAuthenticationRequiredError,
+    SocketSslHandshakeFailedError,
+    SocketProxyConnectionRefusedError,
+    SocketProxyConnectionClosedError,
+    SocketProxyConnectionTimeoutError,
+    SocketProxyNotFoundError,
+    SocketProxyProtocolError,
+    SocketOperationError,
+    SocketSslInternalError,
+    SocketSslInvalidUserDataError,
+    SocketTemporaryError
 };
 
 class ClientPrivate;
@@ -82,6 +106,7 @@ class QMQTTSHARED_EXPORT Client : public QObject
     Q_PROPERTY(QString _password READ password WRITE setPassword)
     Q_PROPERTY(int _keepAlive READ keepAlive WRITE setKeepAlive)
     Q_PROPERTY(bool _autoReconnect READ autoReconnect WRITE setAutoReconnect)
+    Q_PROPERTY(int _autoReconnectInterval READ autoReconnectInterval WRITE setAutoReconnectInterval)
     Q_PROPERTY(bool _cleanSession READ cleanSession WRITE setCleanSession)
     Q_PROPERTY(QString _willTopic READ willTopic WRITE setWillTopic)
     Q_PROPERTY(quint8 _willQos READ willQos WRITE setWillQos)
@@ -145,8 +170,6 @@ public slots:
 signals:
     void connected();
     void disconnected();
-
-    // for pending MQTT protocol errors
     void error(const QMQTT::ClientError error);
 
     // todo: should emit on server suback (or is that only at specific QoS levels?)
@@ -163,6 +186,7 @@ protected slots:
     void onNetworkDisconnected();
     void onNetworkReceived(const QMQTT::Frame& frame);
     void onTimerPingReq();
+    void onNetworkError(QAbstractSocket::SocketError error);
 
 protected:
     QScopedPointer<ClientPrivate> d_ptr;
@@ -173,5 +197,7 @@ private:
 };
 
 } // namespace QMQTT
+
+Q_DECLARE_METATYPE(QMQTT::ClientError);
 
 #endif // QMQTT_CLIENT_H

--- a/src/qmqtt_client.h
+++ b/src/qmqtt_client.h
@@ -110,6 +110,7 @@ public:
     int keepAlive() const;
     bool cleanSession() const;
     bool autoReconnect() const;
+    int autoReconnectInterval() const;
     ConnectionState connectionState() const;
     QString willTopic() const;
     quint8 willQos() const;
@@ -124,9 +125,10 @@ public slots:
     void setClientId(const QString& clientId);
     void setUsername(const QString& username);
     void setPassword(const QString& password);
-    void setKeepAlive(int keepAlive);
-    void setCleanSession(const bool cleansess);
-    void setAutoReconnect(bool value);
+    void setKeepAlive(const int keepAlive);
+    void setCleanSession(const bool cleanSession);
+    void setAutoReconnect(const bool value);
+    void setAutoReconnectInterval(const int autoReconnectInterval);
     void setWillTopic(const QString& willTopic);
     void setWillQos(const quint8 willQos);
     void setWillRetain(const bool willRetain);

--- a/src/qmqtt_client_p.cpp
+++ b/src/qmqtt_client_p.cpp
@@ -372,9 +372,19 @@ bool QMQTT::ClientPrivate::autoReconnect() const
     return _network->autoReconnect();
 }
 
-void QMQTT::ClientPrivate::setAutoReconnect(const bool value)
+void QMQTT::ClientPrivate::setAutoReconnect(const bool autoReconnect)
 {
-    _network->setAutoReconnect(value);
+    _network->setAutoReconnect(autoReconnect);
+}
+
+bool QMQTT::ClientPrivate::autoReconnectInterval() const
+{
+    return _network->autoReconnectInterval();
+}
+
+void QMQTT::ClientPrivate::setAutoReconnectInterval(const int autoReconnectInterval)
+{
+    _network->setAutoReconnectInterval(autoReconnectInterval);
 }
 
 bool QMQTT::ClientPrivate::isConnectedToHost() const

--- a/src/qmqtt_client_p.cpp
+++ b/src/qmqtt_client_p.cpp
@@ -66,7 +66,7 @@ void QMQTT::ClientPrivate::init(const QHostAddress& host, const quint16 port, Ne
 
     _host = host;
     _port = port;
-    if(NULL == network)
+    if(network == NULL)
     {
         _network.reset(new Network);
     }
@@ -75,14 +75,44 @@ void QMQTT::ClientPrivate::init(const QHostAddress& host, const quint16 port, Ne
         _network.reset(network);
     }
 
-    QObject::connect(&_timer, &QTimer::timeout, q, &Client::onTimerPingReq);
+    initializeErrorHash();
 
+    QObject::connect(&_timer, &QTimer::timeout, q, &Client::onTimerPingReq);
     QObject::connect(_network.data(), &Network::connected,
                      q, &Client::onNetworkConnected);
     QObject::connect(_network.data(), &Network::disconnected,
                      q, &Client::onNetworkDisconnected);
     QObject::connect(_network.data(), &Network::received,
                      q, &Client::onNetworkReceived);
+    QObject::connect(_network.data(), &Network::error,
+                     q, &Client::onNetworkError);
+}
+
+void QMQTT::ClientPrivate::initializeErrorHash()
+{
+    _socketErrorHash.insert(QAbstractSocket::ConnectionRefusedError, SocketConnectionRefusedError);
+    _socketErrorHash.insert(QAbstractSocket::RemoteHostClosedError, SocketRemoteHostClosedError);
+    _socketErrorHash.insert(QAbstractSocket::HostNotFoundError, SocketHostNotFoundError);
+    _socketErrorHash.insert(QAbstractSocket::SocketAccessError, SocketAccessError);
+    _socketErrorHash.insert(QAbstractSocket::SocketResourceError, SocketResourceError);
+    _socketErrorHash.insert(QAbstractSocket::SocketTimeoutError, SocketTimeoutError);
+    _socketErrorHash.insert(QAbstractSocket::DatagramTooLargeError, SocketDatagramTooLargeError);
+    _socketErrorHash.insert(QAbstractSocket::NetworkError, SocketNetworkError);
+    _socketErrorHash.insert(QAbstractSocket::AddressInUseError, SocketAddressInUseError);
+    _socketErrorHash.insert(QAbstractSocket::SocketAddressNotAvailableError, SocketAddressNotAvailableError);
+    _socketErrorHash.insert(QAbstractSocket::UnsupportedSocketOperationError, SocketUnsupportedSocketOperationError);
+    _socketErrorHash.insert(QAbstractSocket::UnfinishedSocketOperationError, SocketUnfinishedSocketOperationError);
+    _socketErrorHash.insert(QAbstractSocket::ProxyAuthenticationRequiredError, SocketProxyAuthenticationRequiredError);
+    _socketErrorHash.insert(QAbstractSocket::SslHandshakeFailedError, SocketSslHandshakeFailedError);
+    _socketErrorHash.insert(QAbstractSocket::ProxyConnectionRefusedError, SocketProxyConnectionRefusedError);
+    _socketErrorHash.insert(QAbstractSocket::ProxyConnectionClosedError, SocketProxyConnectionClosedError);
+    _socketErrorHash.insert(QAbstractSocket::ProxyConnectionTimeoutError, SocketProxyConnectionTimeoutError);
+    _socketErrorHash.insert(QAbstractSocket::ProxyNotFoundError, SocketProxyNotFoundError);
+    _socketErrorHash.insert(QAbstractSocket::ProxyProtocolError, SocketProxyProtocolError);
+    _socketErrorHash.insert(QAbstractSocket::OperationError, SocketOperationError);
+    _socketErrorHash.insert(QAbstractSocket::SslInternalError, SocketSslInternalError);
+    _socketErrorHash.insert(QAbstractSocket::SslInvalidUserDataError, SocketSslInvalidUserDataError);
+    _socketErrorHash.insert(QAbstractSocket::TemporaryError, SocketTemporaryError);
 }
 
 void QMQTT::ClientPrivate::connectToHost()
@@ -512,4 +542,10 @@ QString QMQTT::ClientPrivate::willMessage() const
 void QMQTT::ClientPrivate::setWillMessage(const QString& willMessage)
 {
     _willMessage = willMessage;
+}
+
+void QMQTT::ClientPrivate::onNetworkError(QAbstractSocket::SocketError socketError)
+{
+    Q_Q(Client);
+    emit q->error(_socketErrorHash.value(socketError, UnknownError));
 }

--- a/src/qmqtt_client_p.h
+++ b/src/qmqtt_client_p.h
@@ -62,6 +62,7 @@ public:
     quint8 _willQos;
     bool _willRetain;
     QString _willMessage;
+    QHash<QAbstractSocket::SocketError, ClientError> _socketErrorHash;
 
     Client* const q_ptr;
 
@@ -116,6 +117,8 @@ public:
     quint8 willQos() const;
     bool willRetain() const;
     QString willMessage() const;
+    void initializeErrorHash();
+    void onNetworkError(QAbstractSocket::SocketError error);
 
     Q_DECLARE_PUBLIC(Client)
 };

--- a/src/qmqtt_client_p.h
+++ b/src/qmqtt_client_p.h
@@ -89,7 +89,9 @@ public:
     void handlePublish(const Message& message);
     void handlePuback(const quint8 type, const quint16 msgid);
     bool autoReconnect() const;
-    void setAutoReconnect(const bool value);
+    void setAutoReconnect(const bool autoReconnect);
+    bool autoReconnectInterval() const;
+    void setAutoReconnectInterval(const int autoReconnectInterval);
     bool isConnectedToHost() const;
     QMQTT::ConnectionState connectionState() const;
     void setCleanSession(const bool cleanSession);

--- a/src/qmqtt_network.cpp
+++ b/src/qmqtt_network.cpp
@@ -145,7 +145,7 @@ int QMQTT::Network::autoReconnectInterval() const
     return _autoReconnectInterval;
 }
 
-void QMQTT::Network::setAutoReonnectInterval(const int autoReconnectInterval)
+void QMQTT::Network::setAutoReconnectInterval(const int autoReconnectInterval)
 {
     _autoReconnectInterval = autoReconnectInterval;
 }

--- a/src/qmqtt_network.h
+++ b/src/qmqtt_network.h
@@ -62,7 +62,7 @@ public:
     void setAutoReconnect(const bool autoReconnect);
     QAbstractSocket::SocketState state() const;
     int autoReconnectInterval() const;
-    void setAutoReonnectInterval(const int autoReconnectInterval);
+    void setAutoReconnectInterval(const int autoReconnectInterval);
 
 public slots:
     void connectToHost(const QHostAddress& host, const quint16 port);

--- a/src/qmqtt_networkinterface.h
+++ b/src/qmqtt_networkinterface.h
@@ -49,7 +49,9 @@ public:
     virtual void sendFrame(Frame& frame) = 0;
     virtual bool isConnectedToHost() const = 0;
     virtual bool autoReconnect() const = 0;
-    virtual void setAutoReconnect(const bool value) = 0;
+    virtual void setAutoReconnect(const bool autoReconnect) = 0;
+    virtual int autoReconnectInterval() const = 0;
+    virtual void setAutoReconnectInterval(const int autoReconnectInterval) = 0;
     virtual QAbstractSocket::SocketState state() const = 0;
 
 public slots:

--- a/tests/clienttest.cpp
+++ b/tests/clienttest.cpp
@@ -38,7 +38,9 @@ public:
         , _client(new QMQTT::Client(_networkMock))
     {
     }
-    virtual ~ClientTest() {}
+    virtual ~ClientTest()
+    {
+    }
 
     NetworkMock* _networkMock;
     QSharedPointer<QMQTT::Client> _client;
@@ -196,6 +198,24 @@ TEST_F(ClientTest, autoReconnectIsFalseIfNetworkAutoReconnectIsFalse_Test)
 {
     EXPECT_CALL(*_networkMock, autoReconnect()).WillOnce(Return(false));
     EXPECT_FALSE(_client->autoReconnect());
+}
+
+TEST_F(ClientTest, setAutoReconnectSetsNetworkAutoReconnect_Test)
+{
+    EXPECT_CALL(*_networkMock, setAutoReconnect(true));
+    _client->setAutoReconnect(true);
+}
+
+TEST_F(ClientTest, setAutoReconnectIntervalSetsNetworkAutoReconnectInterval_Test)
+{
+    EXPECT_CALL(*_networkMock, setAutoReconnectInterval(10000));
+    _client->setAutoReconnectInterval(10000);
+}
+
+TEST_F(ClientTest, autoReconnectIntervalIsValueOfNetworkAutoReconnect_Test)
+{
+    EXPECT_CALL(*_networkMock, autoReconnectInterval()).WillOnce(Return(10000));
+    EXPECT_TRUE(_client->autoReconnectInterval());
 }
 
 TEST_F(ClientTest, willTopicDefaultsToNull_Test)

--- a/tests/clienttest.cpp
+++ b/tests/clienttest.cpp
@@ -37,10 +37,9 @@ public:
         : _networkMock(new NetworkMock)
         , _client(new QMQTT::Client(_networkMock))
     {
+        qRegisterMetaType<QMQTT::ClientError>("QMQTT::ClientError");
     }
-    virtual ~ClientTest()
-    {
-    }
+    virtual ~ClientTest() {}
 
     NetworkMock* _networkMock;
     QSharedPointer<QMQTT::Client> _client;
@@ -428,4 +427,13 @@ TEST_F(ClientTest, networkDisconnectedEmitsDisconnectedSignal_Test)
     emit _networkMock->disconnected();
 
     EXPECT_EQ(1, spy.count());
+}
+
+TEST_F(ClientTest, clientEmitsErrorWhenNetworkEmitsError_Test)
+{
+    QSignalSpy spy(_client.data(), &QMQTT::Client::error);
+    emit _networkMock->error(QAbstractSocket::ConnectionRefusedError);
+    EXPECT_EQ(1, spy.count());
+    EXPECT_EQ(QMQTT::SocketConnectionRefusedError,
+              spy.at(0).at(0).value<QMQTT::ClientError>());
 }

--- a/tests/networkmock.h
+++ b/tests/networkmock.h
@@ -11,6 +11,8 @@ public:
     MOCK_CONST_METHOD0(isConnectedToHost, bool());
     MOCK_CONST_METHOD0(autoReconnect, bool());
     MOCK_METHOD1(setAutoReconnect, void(const bool));
+    MOCK_CONST_METHOD0(autoReconnectInterval, int());
+    MOCK_METHOD1(setAutoReconnectInterval, void(const int));
     MOCK_CONST_METHOD0(state, QAbstractSocket::SocketState());
     MOCK_METHOD2(connectToHost, void(const QHostAddress&, const quint16));
     MOCK_METHOD0(disconnectFromHost, void());    


### PR DESCRIPTION
* Expose the auto-reconnect feature all the way out to the client user
* Error signalling now works for socket problems