### PR TITLE
Do not set QoS flag on CONNECT

### DIFF
--- a/src/qmqtt_client_p.cpp
+++ b/src/qmqtt_client_p.cpp
@@ -135,7 +135,7 @@ void QMQTT::ClientPrivate::sendConnect()
     quint8 flags = 0;
 
     //header
-    Frame frame(SETQOS(header, QOS1));
+    Frame frame(header);
 
     //flags
     flags = FLAG_CLEANSESS(flags, _cleanSession ? 1 : 0 );


### PR DESCRIPTION
CONNECT packets MUST have all flag bits set to 0.

See Table 2.2 of the spec: http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Table_2.2_-

The flag bits are reserved on CONNECT packages. The sender must not set any flag bits on CONNECT.

In fact the spec states that the server MUST close the connection when invalid flags are received. So this prevents qmqtt from connection to spec-compliant servers.

I tried to connect to Amazon IoT using this library and the connection always got closed, until I found and fixed this.