### PR TITLE
Use proper byte length to encode strings

### DIFF
--- a/src/qmqtt_frame.cpp
+++ b/src/qmqtt_frame.cpp
@@ -120,8 +120,9 @@ void Frame::writeInt(int i)
 
 void Frame::writeString(const QString &string)
 {
-    writeInt(string.size());
-    _data.append(string);
+    QByteArray data = string.toUtf8();
+    writeInt(data.size());
+    _data.append(data);
 }
 
 void Frame::writeChar(const quint8 c)


### PR DESCRIPTION
Frame::writeString() uses QString::size() for the value to write into the string length field.

QString::size() returns the number of characters in the string, which is NOT always equal to the number of bytes in an UTF-8 encoded string.

Your size calculation will fail when the string contains multi-byte characters.