### PR TITLE
Client now emits connected signal after ConnAck has been received.

### DIFF
--- a/src/qmqtt_client_p.cpp
+++ b/src/qmqtt_client_p.cpp
@@ -161,10 +161,8 @@ void QMQTT::ClientPrivate::connectToHost()
 
 void QMQTT::ClientPrivate::onNetworkConnected()
 {
-    Q_Q(Client);
     sendConnect();
     startKeepAlive();
-    emit q->connected();
 }
 
 void QMQTT::ClientPrivate::sendConnect()
@@ -396,8 +394,9 @@ void QMQTT::ClientPrivate::onNetworkReceived(const QMQTT::Frame& frm)
 
 void QMQTT::ClientPrivate::handleConnack(const quint8 ack)
 {
+    Q_Q(Client);
     Q_UNUSED(ack);
-    // todo: send connected signal
+    emit q->connected();
 }
 
 void QMQTT::ClientPrivate::handlePublish(const Message& message)

--- a/tests/clienttest.cpp
+++ b/tests/clienttest.cpp
@@ -371,7 +371,6 @@ TEST_F(ClientTest, disconnectSendsDisconnectMessageAndNetworkDisconnect_Test)
 
 // todo: verify pingreq sent from client, will require timer interface and mock
 
-// todo: this shouldn't emit connected until connect packet received
 TEST_F(ClientTest, networkConnectEmitsConnectedSignal_Test)
 {
     EXPECT_CALL(*_networkMock, sendFrame(_));
@@ -379,7 +378,7 @@ TEST_F(ClientTest, networkConnectEmitsConnectedSignal_Test)
 
     emit _networkMock->connected();
 
-    EXPECT_EQ(1, spy.count());
+    EXPECT_EQ(0, spy.count());
 }
 
 TEST_F(ClientTest, networkReceivedSendsConnackDoesNotEmitConnectedSignal_Test)
@@ -389,7 +388,7 @@ TEST_F(ClientTest, networkReceivedSendsConnackDoesNotEmitConnectedSignal_Test)
     QMQTT::Frame frame(CONNACK_TYPE, QByteArray(2, 0x00));
     emit _networkMock->received(frame);
 
-    EXPECT_EQ(0, spy.count());
+    EXPECT_EQ(1, spy.count());
 }
 
 // todo: receive connack_type should start keepalive


### PR DESCRIPTION
Without this patch, a race condition exists between client and broker. If the client published a message or subscribed when Client::connected was emitted, the request could arrive before the broker had sent ConnAck (because Client::connected was emitted when the TCP connection had been established and the connection request was sent). This could cause the broker to reject/ignore the request.
