### PR TITLE
make it compilable with a namespaced Qt installation

### DIFF
--- a/src/mqtt/qmqtt_socket_p.h
+++ b/src/mqtt/qmqtt_socket_p.h
@@ -36,7 +36,7 @@
 #include <QObject>
 #include <QScopedPointer>
 
-class QTcpSocket;
+QT_FORWARD_DECLARE_CLASS(QTcpSocket)
 
 namespace QMQTT
 {

--- a/src/mqtt/qmqtt_ssl_socket_p.h
+++ b/src/mqtt/qmqtt_ssl_socket_p.h
@@ -39,8 +39,8 @@
 
 #ifndef QT_NO_SSL
 
-class QSslSocket;
-class QSslError;
+QT_FORWARD_DECLARE_CLASS(QSslSocket)
+QT_FORWARD_DECLARE_CLASS(QSslError)
 
 namespace QMQTT
 {


### PR DESCRIPTION
This patch allows to compile the code with a Qt installation, which has been compiled with a namespace (Qt configure called with -qtnamespace XXX -qtlibinfix XXX),
which is needed when an application itself delivers the qt libs so that they do not conflict with the system installed ones (as our commercial product does).

By using the Qt macro QT_FORWARD_DECLARE_CLASS one can compile the same code with or without Qt being namespaced.