### PR TITLE
Bugfix: SSL errors caused by self signed certificates are now ignored if the ignoreSelfSigned options is used.

### DIFF
--- a/src/mqtt/qmqtt_ssl_socket.cpp
+++ b/src/mqtt/qmqtt_ssl_socket.cpp
@@ -105,7 +105,7 @@ void QMQTT::SslSocket::sslErrors(const QList<QSslError> &errors)
         return;
     for (QSslError error: errors)
     {
-        if (error.error() != QSslError::SelfSignedCertificate ||
+        if (error.error() != QSslError::SelfSignedCertificate &&
             error.error() != QSslError::SelfSignedCertificateInChain)
         {
             return;


### PR DESCRIPTION
As discussed in pull request #90 