### PR TITLE
Modifications of signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,10 @@ Signals
     void disconnected();
     void error(const QMQTT::ClientError error);
 
-    // todo: should emit on server suback (or is that only at specific QoS levels?)
-    void subscribed(const QString& topic);
-    // todo: should emit on server unsuback (or is that only at specific QoS levels?)
+    void subscribed(const QString& topic, const quint8 qos);
     void unsubscribed(const QString& topic);
-    // todo: should emit on server puback (or is that only at specific QoS levels?)
-    void published(const QMQTT::Message& message);
-
+    void published(const quint16 msgid, const quint8 qos);
+    void pingresp();
     void received(const QMQTT::Message& message);
 
 
@@ -70,6 +67,8 @@ Contributors
 [@Kampfgnom](https://github.com/Kampfgnom)
 
 [@rafaeldelucena](https://github.com/rafaeldelucena)
+
+[@keytee](https://github.com/keytee)
 
 
 Author

--- a/src/mqtt/qmqtt_client.h
+++ b/src/mqtt/qmqtt_client.h
@@ -193,14 +193,11 @@ signals:
     void disconnected();
     void error(const QMQTT::ClientError error);
 
-    // todo: should emit on server suback (or is that only at specific QoS levels?)
-    void subscribed(const QString& topic);
-    // todo: should emit on server unsuback (or is that only at specific QoS levels?)
+    void subscribed(const QString& topic, const quint8 qos);
     void unsubscribed(const QString& topic);
-    // todo: should emit on server puback (or is that only at specific QoS levels?)
-    void published(const QMQTT::Message& message);
-
+    void published(const quint16 msgid, const quint8 qos);
     void received(const QMQTT::Message& message);
+    void pingresp();
 
 protected slots:
     void onNetworkConnected();

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -99,6 +99,10 @@ public:
     void handleConnack(const quint8 ack);
     void handlePublish(const Message& message);
     void handlePuback(const quint8 type, const quint16 msgid);
+    void handleSuback(const QString& topic, const quint8 qos);
+    void handleUnsuback(const QString& topic);
+    void handlePubcomp(const Message& message);
+    void handlePingresp();
     bool autoReconnect() const;
     void setAutoReconnect(const bool autoReconnect);
     bool autoReconnectInterval() const;


### PR DESCRIPTION
`void subscribed(const QString& topic, const quint8 qos);`
* emits on SUBACK only, and new parameter is the subscribed topic QOS

`void unsubscribed(const QString& topic);`
* emits only on UNSUBACK

`void published(const quint16 msgid, const quint8 qos);`
* changed parameter from QMQTT::Message to msgid and qos
* at QOS0, emits at publish
* at QOS1, emits at PUBACK
* at QOS2, emits at PUBCOMP

`void pingresp();`
* emits at PINGRESP for the possibility of check keepalive from application