### PR TITLE
Fixed unit tests & introduced state engine for message parsing

### DIFF
--- a/src/mqtt/qmqtt_network_p.h
+++ b/src/mqtt/qmqtt_network_p.h
@@ -81,18 +81,26 @@ protected slots:
 
 protected:
     void initialize();
-    int readRemainingLength();
 
     quint16 _port;
     QHostAddress _host;
     QString _hostName;
-    QByteArray _buffer;
     bool _autoReconnect;
     int _autoReconnectInterval;
-    int _bytesRemaining;
-    quint8 _header;
     SocketInterface* _socket;
     TimerInterface* _autoReconnectTimer;
+
+    enum ReadState {
+        Header,
+        Length,
+        PayLoad
+    };
+
+    ReadState _readState;
+    quint8 _header;
+    int _length;
+    int _shift;
+    QByteArray _data;
 
 protected slots:
     void onSocketReadReady();

--- a/tests/gtest/tests/iodevicemock.h
+++ b/tests/gtest/tests/iodevicemock.h
@@ -13,6 +13,7 @@ public:
     MOCK_METHOD2(readData, qint64(char*, qint64));
     MOCK_METHOD2(writeData, qint64(const char *, qint64));
     MOCK_CONST_METHOD0(openMode, QIODevice::OpenMode());
+    MOCK_CONST_METHOD0(bytesAvailable, qint64());
 
     MOCK_METHOD2(write, qint64(const char*, qint64));
     MOCK_METHOD1(write, qint64(const char*));

--- a/tests/gtest/tests/networktest.cpp
+++ b/tests/gtest/tests/networktest.cpp
@@ -52,9 +52,9 @@ public:
         return actualLength;
     }
 
-    bool fixtureByteArrayIsEmpty() const
+    qint64 fixtureBytesAvailable() const
     {
-        return _byteArray.isEmpty();
+        return _byteArray.size();
     }
 
     SocketMock* _socketMock;
@@ -164,8 +164,8 @@ TEST_F(NetworkTest, networkEmitsReceivedSignalOnceAFrameIsReceived_Test)
     buffer.close();
     EXPECT_EQ(132, _byteArray.size());
 
-    EXPECT_CALL(*_socketMock->mockIoDevice, atEnd())
-        .WillRepeatedly(Invoke(this, &NetworkTest::fixtureByteArrayIsEmpty));
+    EXPECT_CALL(*_socketMock->mockIoDevice, bytesAvailable())
+        .WillRepeatedly(Invoke(this, &NetworkTest::fixtureBytesAvailable));
     EXPECT_CALL(*_socketMock->mockIoDevice, readData(_, _))
         .WillRepeatedly(Invoke(this, &NetworkTest::readDataFromFixtureByteArray));
 


### PR DESCRIPTION
2 independent changes:
1. First of all, some unit tests failed due to commit #96. The problems are caused by the fact that the signals no longer pass a QMTT::Message object. And in some cases, the signals are delayed, so the unit tests have to send a mock MQTT response to get stuff working again.
1. A rewrite of the message parsing code. We have created a simple state engine to parse the incoming MQTT messages. The problem with the original code was that sometimes (usually when receiving many retained messages as response to a wildcard subscription) the QMQTT library would emit a QAbstractSocket::OperationError error in Network and close the TCP socket. The code checks if there is data available for reading (using `!ioDevice->atEnd()`), and if so, it will read the header byte and the length of the message. Problem is that there may be just 1 byte available at that time, which means that the header is read from the socket, but reading the message length fails. This triggers the OperationError. This patch starts with reading all available data in the `Network::onSocketReadReady` slot and handle it byte for byte. This ensures that the library will never try to read data that is not available yet.

To illustrate the problem we added an additional `qDebug` statement to Network::onSocketReadReady:
```
while(!ioDevice->atEnd())
{
        int bytesAvailableStartOfLoop = ioDevice->bytesAvailable();
        if(_bytesRemaining == 0)
        {
            if (!ioDevice->getChar(reinterpret_cast<char *>(&_header)))
            {
                // malformed packet
                emit error(QAbstractSocket::OperationError);
                ioDevice->close();
                return;
            }
            int bytesAvailableAfterReadingHeader = ioDevice->bytesAvailable();
            _bytesRemaining = readRemainingLength();
            if (_bytesRemaining < 0)
            {
                // malformed remaining length
                qDebug() << "bytesremaining start of loop:" << bytesAvailableStartOfLoop << ". then right before reading packet length: " << bytesAvailableAfterReadingHeader;
                emit error(QAbstractSocket::OperationError);
                ioDevice->close();
                return;
            }
        }
```
When the bug is triggered, the output is:
```
bytesremaining start of loop: 1 . then right before reading packet length:  0
```
