### PR TITLE
Bug fix: empty topic string passed to (un)subscribed signals

### DIFF
--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -336,12 +336,14 @@ void QMQTT::ClientPrivate::puback(const quint8 type, const quint16 msgid)
 quint16 QMQTT::ClientPrivate::subscribe(const QString& topic, const quint8 qos)
 {
     quint16 msgid = sendSubscribe(topic, qos);
+    _midToTopic[msgid] = topic;
     return msgid;
 }
 
 void QMQTT::ClientPrivate::unsubscribe(const QString& topic)
 {
-    sendUnsubscribe(topic);
+    quint16 msgid = sendUnsubscribe(topic);
+    _midToTopic[msgid] = topic;
 }
 
 void QMQTT::ClientPrivate::onNetworkDisconnected()
@@ -349,6 +351,7 @@ void QMQTT::ClientPrivate::onNetworkDisconnected()
     Q_Q(Client);
 
     stopKeepAlive();
+    clearMidToTopic();
     emit q->disconnected();
 }
 
@@ -395,10 +398,11 @@ void QMQTT::ClientPrivate::onNetworkReceived(const QMQTT::Frame& frm)
     case SUBACK:
         mid = frame.readInt();
         qos = frame.readChar();
-        handleSuback(topic, qos);
+        handleSuback(midToTopic(mid), qos);
         break;
     case UNSUBACK:
-        handleUnsuback(topic);
+        mid = frame.readInt();
+        handleUnsuback(midToTopic(mid));
         break;
     case PINGRESP:
 
@@ -466,6 +470,22 @@ void QMQTT::ClientPrivate::handleSuback(const QString &topic, const quint8 qos) 
 void QMQTT::ClientPrivate::handleUnsuback(const QString &topic) {
     Q_Q(Client);
     emit q->unsubscribed(topic);
+}
+
+QString QMQTT::ClientPrivate::midToTopic(const quint16 mid)
+{
+    QString result;
+    QHash<quint16, QString>::Iterator it = _midToTopic.find(mid);
+    if (it != _midToTopic.end()) {
+        result = it.value();
+        _midToTopic.erase(it);
+    }
+    return result;
+}
+
+void QMQTT::ClientPrivate::clearMidToTopic()
+{
+    _midToTopic.clear();
 }
 
 bool QMQTT::ClientPrivate::autoReconnect() const

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -74,6 +74,7 @@ public:
     bool _willRetain;
     QString _willMessage;
     QHash<QAbstractSocket::SocketError, ClientError> _socketErrorHash;
+    QHash<quint16, QString> _midToTopic;
 
     Client* const q_ptr;
 
@@ -103,6 +104,8 @@ public:
     void handleUnsuback(const QString& topic);
     void handlePubcomp(const Message& message);
     void handlePingresp();
+    QString midToTopic(const quint16 mid);
+    void clearMidToTopic();
     bool autoReconnect() const;
     void setAutoReconnect(const bool autoReconnect);
     bool autoReconnectInterval() const;


### PR DESCRIPTION
This fixes issue #98.