### PR TITLE
Fixed missing handlePingresp() callback in switch

### DIFF
--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -401,7 +401,7 @@ void QMQTT::ClientPrivate::onNetworkReceived(const QMQTT::Frame& frm)
         handleUnsuback(topic);
         break;
     case PINGRESP:
-
+        handlePingresp();
         break;
     default:
         break;


### PR DESCRIPTION
Commits split as per request in: #99 

This commit fixes a missing callback.