### PR TITLE
Simplify (un)subscribe

### DIFF
--- a/src/mqtt/qmqtt_client.cpp
+++ b/src/mqtt/qmqtt_client.cpp
@@ -293,10 +293,10 @@ quint16 QMQTT::Client::publish(const Message& message)
     return d->publish(message);
 }
 
-quint16 QMQTT::Client::subscribe(const QString& topic, const quint8 qos)
+void QMQTT::Client::subscribe(const QString& topic, const quint8 qos)
 {
     Q_D(Client);
-    return d->subscribe(topic, qos);
+    d->subscribe(topic, qos);
 }
 
 void QMQTT::Client::unsubscribe(const QString& topic)

--- a/src/mqtt/qmqtt_client.h
+++ b/src/mqtt/qmqtt_client.h
@@ -187,7 +187,7 @@ public slots:
     void connectToHost();
     void disconnectFromHost();
 
-    quint16 subscribe(const QString& topic, const quint8 qos);
+    void subscribe(const QString& topic, const quint8 qos = 0);
     void unsubscribe(const QString& topic);
 
     quint16 publish(const Message& message);
@@ -197,7 +197,7 @@ signals:
     void disconnected();
     void error(const QMQTT::ClientError error);
 
-    void subscribed(const QString& topic, const quint8 qos);
+    void subscribed(const QString& topic, const quint8 qos = 0);
     void unsubscribed(const QString& topic);
     void published(const quint16 msgid, const quint8 qos);
     void received(const QMQTT::Message& message);

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -95,7 +95,7 @@ public:
     void onNetworkDisconnected();
     quint16 publish(const Message& message);
     void puback(const quint8 type, const quint16 msgid);
-    quint16 subscribe(const QString& topic, const quint8 qos);
+    void subscribe(const QString& topic, const quint8 qos);
     void unsubscribe(const QString& topic);
     void onNetworkReceived(const QMQTT::Frame& frame);
     void handleConnack(const quint8 ack);
@@ -105,8 +105,6 @@ public:
     void handleUnsuback(const QString& topic);
     void handlePubcomp(const Message& message);
     void handlePingresp();
-    QString midToTopic(const quint16 mid);
-    void clearMidToTopic();
     bool autoReconnect() const;
     void setAutoReconnect(const bool autoReconnect);
     bool autoReconnectInterval() const;

--- a/tests/gtest/tests/clienttest.cpp
+++ b/tests/gtest/tests/clienttest.cpp
@@ -431,11 +431,11 @@ TEST_F(ClientTest, subscribeEmitsSubscribedSignal_Test)
     EXPECT_CALL(*_networkMock, sendFrame(_));
     QSignalSpy spy(_client.data(), &QMQTT::Client::subscribed);
 
-    quint16 msgid = _client->subscribe("topic", QOS2);
+    _client->subscribe("topic", QOS2);
 
     QByteArray payLoad;
-    payLoad.append((char)(msgid >> 8)); // message ID MSB
-    payLoad.append((char)(msgid && 0xFF)); // message ID LSB
+    payLoad.append((char)0x00); // message ID MSB
+    payLoad.append((char)0x01); // message ID LSB
     payLoad.append((char)QOS2); // QOS
     QMQTT::Frame frame(SUBACK_TYPE, payLoad);
     emit _networkMock->received(frame);


### PR DESCRIPTION
Make calls more user-friendly by making the 'qos' param optional.
Do not expose packet id as it couldn't be used for/compared to
anything outside ClientPrivate; also makes (un)subscribe symmetrical.
Inline some code.
Complements 3d6354e9f0598