### PR TITLE
Make published() signal more application-friendly

### DIFF
--- a/src/mqtt/qmqtt_client.h
+++ b/src/mqtt/qmqtt_client.h
@@ -199,7 +199,7 @@ signals:
 
     void subscribed(const QString& topic, const quint8 qos = 0);
     void unsubscribed(const QString& topic);
-    void published(const quint16 msgid, const quint8 qos);
+    void published(const QMQTT::Message& message, quint16 msgid = 0);
     void received(const QMQTT::Message& message);
     void pingresp();
 

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -76,6 +76,7 @@ public:
     QByteArray _willMessage;
     QHash<QAbstractSocket::SocketError, ClientError> _socketErrorHash;
     QHash<quint16, QString> _midToTopic;
+    QHash<quint16, Message> _midToMessage;
 
     Client* const q_ptr;
 

--- a/tests/gtest/tests/clienttest.cpp
+++ b/tests/gtest/tests/clienttest.cpp
@@ -405,11 +405,11 @@ TEST_F(ClientTest, publishEmitsPublishedSignal_Test)
     QSignalSpy spy(_client.data(), &QMQTT::Client::published);
     QMQTT::Message message(222, "topic", QByteArray("payload"));
 
-    _client->publish(message);
+    quint16 msgid = _client->publish(message);
 
     ASSERT_EQ(1, spy.count());
-    EXPECT_EQ(message.id(), spy.at(0).at(0).value<quint16>());
-    EXPECT_EQ(QOS0, spy.at(0).at(1).value<quint8>());
+    EXPECT_EQ(message, spy.at(0).at(0).value<QMQTT::Message>());
+    EXPECT_EQ(msgid, spy.at(0).at(1).value<quint16>());
 }
 
 // todo: network received sends a puback, test what happens


### PR DESCRIPTION
The signature has been changed in 83ad60daee086b0fdf501
to return just msgid and qos, forcing the application
to track all messages queued for publishing
just to recover them by msgid later, if used.

The messages queue will be required for implementing the proper
messages delivery ordering at QOS1 and QOS2, so start tracking
published messages in qmqtt (somewhat similar to 3d6354e9f and 21e2b4d90)