### PR TITLE
Support for websockets & minor changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
+language: cpp
+compiler:
+ - gcc
+
 before_install:
  - sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
- - sudo apt-add-repository -y ppa:beineri/opt-qt56
+ - sudo apt-add-repository -y ppa:beineri/opt-qt571-trusty
  - sudo apt-get update -qq
- - sudo apt-get install -qq qt56base qt56tools g++-4.8
- - source /opt/qt56/bin/qt56-env.sh
- - export CXX="g++-4.8"
+ - sudo apt-get install -qq qt57base qt57tools qt57websockets g++-5
+ - source /opt/qt57/bin/qt57-env.sh
+ - export CXX="g++-5"
+ - export CC="gcc-5"
 
 script:
  - qmake --version

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ Usage
     client->setPassword("password");
     client->connectToHost();
 
+Connect using ssl:
+
+    QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
+    // Add custom SSL options here (for example extra certificates)
+    QMQTT::Client *client = new QMQTT::Client("example.com", 8883, sslConfig);
+    client->setClientId("clientId");
+    client->setUsername("user");
+    client->setPassword("password");
+    client->connectToHost();
+
 Slots
 =====
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ mqtt client for Qt
 
 **Please compile the library with Qt >= 5.3 version. On Windows you need to specify `CONFIG += NO_UNIT_TESTS`, since gtest is not supported.**
 
+To add websocket support, compile the library with Qt >= 5.7, and specify 'CONFIG += QMQTT_WEBSOCKETS'.
+
 Usage
 =====
 
@@ -21,6 +23,14 @@ Connect using ssl:
     QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
     // Add custom SSL options here (for example extra certificates)
     QMQTT::Client *client = new QMQTT::Client("example.com", 8883, sslConfig);
+    client->setClientId("clientId");
+    client->setUsername("user");
+    client->setPassword("password");
+    client->connectToHost();
+
+Connect using websockets:
+
+    QMQTT::Client *client = new QMQTT::Client("ws://www.example.com/mqtt", "<origin>", QWebSocketProtocol::VersionLatest);
     client->setClientId("clientId");
     client->setUsername("user");
     client->setPassword("password");

--- a/src/mqtt/mqtt.pri
+++ b/src/mqtt/mqtt.pri
@@ -17,7 +17,9 @@ PRIVATE_HEADERS += \
     $$PWD/qmqtt_network_p.h \
     $$PWD/qmqtt_socket_p.h \
     $$PWD/qmqtt_ssl_socket_p.h \
-    $$PWD/qmqtt_timer_p.h
+    $$PWD/qmqtt_timer_p.h \
+    $$PWD/qmqtt_websocket_p.h \
+    $$PWD/qmqtt_websocketiodevice_p.h
 
 SOURCES += \
     $$PWD/qmqtt_client_p.cpp \
@@ -30,4 +32,6 @@ SOURCES += \
     $$PWD/qmqtt_message_p.cpp \
     $$PWD/qmqtt_socket.cpp \
     $$PWD/qmqtt_ssl_socket.cpp \
-    $$PWD/qmqtt_timer.cpp
+    $$PWD/qmqtt_timer.cpp \
+    $$PWD/qmqtt_websocket.cpp \
+    $$PWD/qmqtt_websocketiodevice.cpp

--- a/src/mqtt/mqtt.pro
+++ b/src/mqtt/mqtt.pro
@@ -1,5 +1,6 @@
 TARGET = qmqtt
 QT = core network
+QMQTT_WEBSOCKETS: QT += websockets
 
 DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 

--- a/src/mqtt/mqtt.qbs
+++ b/src/mqtt/mqtt.qbs
@@ -7,6 +7,7 @@ Product {
         libraryType,
         "mqttmodule",
     ]
+    property bool webSocketSupport: false
     property string libraryType: "dynamiclibrary"
     targetName: "qmqtt"
 
@@ -87,10 +88,16 @@ Product {
 
     Depends {
         name: "Qt"
-        submodules: [
-            "core",
-            "network",
-        ]
+        property var baseModules: ["core", "network"]
+
+        Properties {
+            condition: webSocketSupport
+            submodules: baseModules.concat(["websockets"])
+        }
+        Properties {
+            condition: !webSocketSupport
+            submodules: baseModules
+        }
     }
 
     Export {
@@ -100,10 +107,15 @@ Product {
 
         Depends {
             name: "Qt"
-            submodules: [
-                "core",
-                "network",
-            ]
+            property var baseModules: ["core", "network"]
+            Properties {
+                condition: product.webSocketSupport
+                submodules: baseModules.concat(["websockets"])
+            }
+            Properties {
+                condition: !product.webSocketSupport
+                submodules: baseModules
+            }
         }
 
         cpp.includePaths: product.sourceDirectory

--- a/src/mqtt/qmqtt_client.cpp
+++ b/src/mqtt/qmqtt_client.cpp
@@ -68,6 +68,20 @@ QMQTT::Client::Client(const QString &hostName,
     d->init(hostName, port, ssl, ignoreSelfSigned);
 }
 
+#ifdef QT_WEBSOCKETS_LIB
+QMQTT::Client::Client(const QString& url,
+                      const QString& origin,
+                      QWebSocketProtocol::Version version,
+                      bool ignoreSelfSigned,
+                      QObject* parent)
+    : QObject(parent)
+    , d_ptr(new ClientPrivate(this))
+{
+    Q_D(Client);
+    d->init(url, origin, version, ignoreSelfSigned);
+}
+#endif // QT_WEBSOCKETS_LIB
+
 QMQTT::Client::Client(NetworkInterface* network,
                       const QHostAddress& host,
                       const quint16 port,

--- a/src/mqtt/qmqtt_client.h
+++ b/src/mqtt/qmqtt_client.h
@@ -39,6 +39,10 @@
 #include <QScopedPointer>
 #include <QHostAddress>
 
+#ifdef QT_WEBSOCKETS_LIB
+#include <QWebSocket>
+#endif // QT_WEBSOCKETS_LIB
+
 #ifndef QT_NO_SSL
 QT_FORWARD_DECLARE_CLASS(QSslConfiguration)
 #endif // QT_NO_SSL
@@ -139,6 +143,15 @@ public:
            const bool ssl,
            const bool ignoreSelfSigned,
            QObject* parent = NULL);
+
+#ifdef QT_WEBSOCKETS_LIB
+    // Create a connection over websockets
+    Client(const QString& url,
+           const QString& origin,
+           QWebSocketProtocol::Version version,
+           bool ignoreSelfSigned = false,
+           QObject* parent = NULL);
+#endif // QT_WEBSOCKETS_LIB
 
     // for testing purposes only
     Client(NetworkInterface* network,

--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -118,6 +118,15 @@ void QMQTT::ClientPrivate::init(const QString& hostName, const quint16 port, con
     }
 }
 
+#ifdef QT_WEBSOCKETS_LIB
+void QMQTT::ClientPrivate::init(const QString& url, const QString& origin,
+                                QWebSocketProtocol::Version version, bool ignoreSelfSigned)
+{
+    _hostName = url;
+    init(new Network(origin, version, ignoreSelfSigned));
+}
+#endif // QT_WEBSOCKETS_LIB
+
 void QMQTT::ClientPrivate::init(NetworkInterface* network)
 {
     Q_Q(Client);

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -37,6 +37,10 @@
 #include "qmqtt_network_p.h"
 #include <QTimer>
 
+#ifdef QT_WEBSOCKETS_LIB
+#include <QWebSocket>
+#endif // QT_WEBSOCKETS_LIB
+
 #ifndef QT_NO_SSL
 QT_FORWARD_DECLARE_CLASS(QSslConfiguration)
 #endif // QT_NO_SSL
@@ -55,11 +59,18 @@ public:
               const bool ignoreSelfSigned=false);
 #endif // QT_NO_SSL
     void init(const QString& hostName, const quint16 port, const bool ssl, const bool ignoreSelfSigned);
+#ifdef QT_WEBSOCKETS_LIB
+    void init(const QString& url, const QString &origin, QWebSocketProtocol::Version version,
+              bool ignoreSelfSigned);
+#endif // QT_WEBSOCKETS_LIB
     void init(NetworkInterface* network);
 
     QHostAddress _host;
     QString _hostName;
     quint16 _port;
+#ifdef QT_WEBSOCKETS_LIB
+    QWebSocketProtocol::Version _webSocketVersion;
+#endif // QT_WEBSOCKETS_LIB
     quint16 _gmid;
     MQTTVersion _version;
     QString _clientId;

--- a/src/mqtt/qmqtt_network.cpp
+++ b/src/mqtt/qmqtt_network.cpp
@@ -34,6 +34,7 @@
 #include "qmqtt_socket_p.h"
 #include "qmqtt_ssl_socket_p.h"
 #include "qmqtt_timer_p.h"
+#include "qmqtt_websocket_p.h"
 
 const QString DEFAULT_HOST_NAME = QStringLiteral("localhost");
 const QHostAddress DEFAULT_HOST = QHostAddress::LocalHost;
@@ -69,6 +70,22 @@ QMQTT::Network::Network(const QSslConfiguration &config, bool ignoreSelfSigned, 
     initialize();
 }
 #endif // QT_NO_SSL
+
+#ifdef QT_WEBSOCKETS_LIB
+QMQTT::Network::Network(const QString& origin, QWebSocketProtocol::Version version,
+                        bool ignoreSelfSigned, QObject* parent)
+    : NetworkInterface(parent)
+    , _port(DEFAULT_SSL_PORT)
+    , _hostName(DEFAULT_HOST_NAME)
+    , _autoReconnect(DEFAULT_AUTORECONNECT)
+    , _autoReconnectInterval(DEFAULT_AUTORECONNECT_INTERVAL_MS)
+    , _socket(new QMQTT::WebSocket(origin, version, ignoreSelfSigned))
+    , _autoReconnectTimer(new QMQTT::Timer)
+    , _readState(Header)
+{
+    initialize();
+}
+#endif // QT_WEBSOCKETS_LIB
 
 QMQTT::Network::Network(SocketInterface* socketInterface, TimerInterface* timerInterface,
                         QObject* parent)

--- a/src/mqtt/qmqtt_network_p.h
+++ b/src/mqtt/qmqtt_network_p.h
@@ -40,6 +40,10 @@
 #include <QByteArray>
 #include <QHostAddress>
 
+#ifdef QT_WEBSOCKETS_LIB
+#include <QWebSocket>
+#endif // QT_WEBSOCKETS_LIB
+
 #ifndef QT_NO_SSL
 QT_FORWARD_DECLARE_CLASS(QSslConfiguration)
 #endif // QT_NO_SSL
@@ -58,6 +62,10 @@ public:
 #ifndef QT_NO_SSL
     Network(const QSslConfiguration& config, bool ignoreSelfSigned, QObject* parent = NULL);
 #endif // QT_NO_SSL
+#ifdef QT_WEBSOCKETS_LIB
+    Network(const QString& origin, QWebSocketProtocol::Version version, bool ignoreSelfSigned,
+            QObject* parent = NULL);
+#endif // QT_WEBSOCKETS_LIB
     Network(SocketInterface* socketInterface, TimerInterface* timerInterface,
             QObject* parent = NULL);
     ~Network();

--- a/src/mqtt/qmqtt_websocket.cpp
+++ b/src/mqtt/qmqtt_websocket.cpp
@@ -1,0 +1,73 @@
+#ifdef QT_WEBSOCKETS_LIB
+
+#include <QNetworkRequest>
+#include <QUrl>
+#include "qmqtt_websocket_p.h"
+
+QMQTT::WebSocket::WebSocket(const QString& origin, QWebSocketProtocol::Version version,
+                            bool ignoreSelfSigned, QObject* parent)
+    : SocketInterface(parent)
+    , _socket(new QWebSocket(origin, version, this))
+    , _ioDevice(new WebSocketIODevice(_socket, this))
+    , _ignoreSelfSigned(ignoreSelfSigned)
+{
+    connect(_socket, &QWebSocket::connected, this, &WebSocket::connected);
+    connect(_socket, &QWebSocket::disconnected, this, &WebSocket::disconnected);
+    connect(_socket,
+            static_cast<void (QWebSocket::*)(QAbstractSocket::SocketError)>(&QWebSocket::error),
+            this,
+            static_cast<void (SocketInterface::*)(QAbstractSocket::SocketError)>(&SocketInterface::error));
+    connect(_socket, &QWebSocket::sslErrors, this, &WebSocket::sslErrors);
+}
+
+QMQTT::WebSocket::~WebSocket()
+{
+}
+
+void QMQTT::WebSocket::connectToHost(const QHostAddress& address, quint16 port)
+{
+    Q_UNUSED(address)
+    Q_UNUSED(port)
+    qFatal("No supported");
+}
+
+void QMQTT::WebSocket::connectToHost(const QString& hostName, quint16 port)
+{
+    Q_UNUSED(port)
+    QUrl url(hostName);
+    QNetworkRequest request(url);
+    request.setRawHeader("Sec-WebSocket-Protocol", "mqtt");
+    _ioDevice->connectToHost(request);
+}
+
+void QMQTT::WebSocket::disconnectFromHost()
+{
+    _socket->disconnect();
+}
+
+QAbstractSocket::SocketState QMQTT::WebSocket::state() const
+{
+    return  _socket->state();
+}
+
+QAbstractSocket::SocketError QMQTT::WebSocket::error() const
+{
+    return _socket->error();
+}
+
+void QMQTT::WebSocket::sslErrors(const QList<QSslError> &errors)
+{
+    if (!_ignoreSelfSigned)
+        return;
+    foreach (QSslError error, errors)
+    {
+        if (error.error() != QSslError::SelfSignedCertificate &&
+            error.error() != QSslError::SelfSignedCertificateInChain)
+        {
+            return;
+        }
+    }
+    _socket->ignoreSslErrors();
+}
+
+#endif // QT_WEBSOCKETS_LIB

--- a/src/mqtt/qmqtt_websocket_p.h
+++ b/src/mqtt/qmqtt_websocket_p.h
@@ -1,0 +1,77 @@
+/*
+ * qmqtt_websocket_p.h - qmqtt socket private header
+ *
+ * Copyright (c) 2013  Ery Lee <ery.lee at gmail dot com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of mqttc nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef QMQTT_WEBSOCKET_H
+#define QMQTT_WEBSOCKET_H
+
+#ifdef QT_WEBSOCKETS_LIB
+
+#include "qmqtt_socketinterface.h"
+#include "qmqtt_websocketiodevice_p.h"
+#include <QWebSocket>
+
+namespace QMQTT
+{
+
+class WebSocket : public SocketInterface
+{
+public:
+    WebSocket(const QString& origin, QWebSocketProtocol::Version version, bool ignoreSelfSigned,
+              QObject* parent = NULL);
+    virtual ~WebSocket();
+
+    QIODevice *ioDevice()
+    {
+        return _ioDevice;
+    }
+
+    void connectToHost(const QHostAddress& address, quint16 port);
+    void connectToHost(const QString& hostName, quint16 port);
+    void disconnectFromHost();
+    QAbstractSocket::SocketState state() const;
+    QAbstractSocket::SocketError error() const;
+
+    // using SocketInterface::error;
+
+private slots:
+    void sslErrors(const QList<QSslError> &errors);
+
+private:
+    QWebSocket *_socket;
+    WebSocketIODevice *_ioDevice;
+    bool _ignoreSelfSigned;
+};
+
+}
+
+#endif // QT_WEBSOCKETS_LIB
+
+#endif // QMQTT_WEBSOCKET_H

--- a/src/mqtt/qmqtt_websocketiodevice.cpp
+++ b/src/mqtt/qmqtt_websocketiodevice.cpp
@@ -1,0 +1,46 @@
+#ifdef QT_WEBSOCKETS_LIB
+
+#include "qmqtt_websocketiodevice_p.h"
+
+QMQTT::WebSocketIODevice::WebSocketIODevice(QWebSocket *socket, QObject *parent)
+    : QIODevice(parent)
+    , _webSocket(socket)
+{
+    connect(_webSocket, &QWebSocket::bytesWritten, this, &WebSocketIODevice::bytesWritten);
+    connect(_webSocket, &QWebSocket::binaryMessageReceived,
+            this, &WebSocketIODevice::binaryMessageReceived);
+}
+
+bool QMQTT::WebSocketIODevice::connectToHost(const QNetworkRequest &request)
+{
+    _webSocket->open(request);
+    return QIODevice::open(QIODevice::ReadWrite);
+}
+
+qint64 QMQTT::WebSocketIODevice::bytesAvailable() const
+{
+    return _buffer.count();
+}
+
+void QMQTT::WebSocketIODevice::binaryMessageReceived(const QByteArray &frame)
+{
+    _buffer.append(frame);
+    emit readyRead();
+}
+
+qint64 QMQTT::WebSocketIODevice::readData(char *data, qint64 maxSize)
+{
+    int size = qMin(static_cast<int>(maxSize), _buffer.count());
+    for (int i=0; i<size; ++ i)
+        data[i] = _buffer[i];
+    _buffer.remove(0, size);
+    return size;
+}
+
+qint64 QMQTT::WebSocketIODevice::writeData(const char *data, qint64 maxSize)
+{
+    QByteArray d(data, static_cast<int>(maxSize));
+    return _webSocket->sendBinaryMessage(d);
+}
+
+#endif // QT_WEBSOCKETS_LIB

--- a/src/mqtt/qmqtt_websocketiodevice_p.h
+++ b/src/mqtt/qmqtt_websocketiodevice_p.h
@@ -1,0 +1,81 @@
+/*
+ * qmqtt_socketinterface.h - qmqtt socket interface header
+ *
+ * Copyright (c) 2013  Ery Lee <ery.lee at gmail dot com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of mqttc nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef QMQTT_WEBSOCKETIODEVICE_H
+#define QMQTT_WEBSOCKETIODEVICE_H
+
+#ifdef QT_WEBSOCKETS_LIB
+
+#include <QByteArray>
+#include <QIODevice>
+#include <QWebSocket>
+
+namespace QMQTT
+{
+
+class WebSocketIODevice : public QIODevice
+{
+    Q_OBJECT
+public:
+    explicit WebSocketIODevice(QWebSocket *socket, QObject *parent = NULL);
+
+    bool connectToHost(const QNetworkRequest &request);
+
+    virtual qint64 bytesAvailable() const;
+
+signals:
+    void connected();
+
+    void disconnected();
+
+    void error(QAbstractSocket::SocketError error);
+
+    void sslErrors(const QList<QSslError> &errors);
+
+protected:
+    virtual qint64 readData(char *data, qint64 maxSize);
+
+    virtual qint64 writeData(const char *data, qint64 maxSize);
+
+private slots:
+    void binaryMessageReceived(const QByteArray &frame);
+
+private:
+    QByteArray _buffer;
+    QWebSocket *_webSocket;
+};
+
+}
+
+#endif // QT_WEBSOCKETS_LIB
+
+#endif // QMQTT_WEBSOCKETIODEVICE_H

--- a/tests/gtest/tests/messagetest.cpp
+++ b/tests/gtest/tests/messagetest.cpp
@@ -37,9 +37,9 @@ TEST_F(MessageTest, constructorWithParametersHasDefaultValues_Test)
 
 TEST_F(MessageTest, constructorWithParameters_Test)
 {
-    _message.reset(new QMQTT::Message(5, "topic", "payload", 5, true, true));
+    _message.reset(new QMQTT::Message(5, "topic", "payload", 2, true, true));
     EXPECT_EQ(5, _message->id());
-    EXPECT_EQ(5, _message->qos());
+    EXPECT_EQ(2, _message->qos());
     EXPECT_TRUE(_message->retain());
     EXPECT_TRUE(_message->dup());
     EXPECT_EQ(QString("topic"), _message->topic());
@@ -48,11 +48,11 @@ TEST_F(MessageTest, constructorWithParameters_Test)
 
 TEST_F(MessageTest, copyConstructor_Test)
 {
-    QMQTT::Message originalMessage(5, "topic", "payload", 5, true, true);
+    QMQTT::Message originalMessage(5, "topic", "payload", 1, true, true);
     QMQTT::Message copy(originalMessage);
-    _message.reset(new QMQTT::Message(5, "topic", "payload", 5, true, true));
+    _message.reset(new QMQTT::Message(5, "topic", "payload", 1, true, true));
     EXPECT_EQ(5, copy.id());
-    EXPECT_EQ(5, copy.qos());
+    EXPECT_EQ(1, copy.qos());
     EXPECT_TRUE(copy.retain());
     EXPECT_TRUE(copy.dup());
     EXPECT_EQ(QString("topic"), copy.topic());
@@ -61,13 +61,13 @@ TEST_F(MessageTest, copyConstructor_Test)
 
 TEST_F(MessageTest, assignmentOperator_Test)
 {
-    QMQTT::Message originalMessage(5, "topic", "payload", 5, true, true);
+    QMQTT::Message originalMessage(5, "topic", "payload", 2, true, true);
     QMQTT::Message copy;
 
     copy = originalMessage;
 
     EXPECT_EQ(5, copy.id());
-    EXPECT_EQ(5, copy.qos());
+    EXPECT_EQ(2, copy.qos());
     EXPECT_TRUE(copy.retain());
     EXPECT_TRUE(copy.dup());
     EXPECT_EQ(QString("topic"), copy.topic());
@@ -83,8 +83,8 @@ TEST_F(MessageTest, idSettable_Test)
 
 TEST_F(MessageTest, qosSettable_Test)
 {
-    _message->setQos(5);
-    EXPECT_EQ(5, _message->qos());
+    _message->setQos(1);
+    EXPECT_EQ(1, _message->qos());
 }
 
 TEST_F(MessageTest, retainSettable_Test)


### PR DESCRIPTION
* Added support for websockets. This will only work for QT>5.7, because the library needs a version of the `QWebSocket::open` function which was added in this version. Websocket support is disabled by default (because is requires the QT websockets module which may not always be present). The readme has info on how to enable support. I have only tested this with the EMQ broker.
* Fixed the unit tests
* Added an example to the readme on how to create an SSL connection.
