### PR TITLE
Bug fix: QObject::disconnect called when connection over websocket is closed

### DIFF
--- a/src/mqtt/qmqtt_websocket.cpp
+++ b/src/mqtt/qmqtt_websocket.cpp
@@ -42,7 +42,7 @@ void QMQTT::WebSocket::connectToHost(const QString& hostName, quint16 port)
 
 void QMQTT::WebSocket::disconnectFromHost()
 {
-    _socket->disconnect();
+    _socket->close();
 }
 
 QAbstractSocket::SocketState QMQTT::WebSocket::state() const


### PR DESCRIPTION
Replaced with QWebSocket::close.

This bug was reported by Seunghyo Lee.
