### PR TITLE
Satisfy GCC pedantic build by removing extra semicolon, Q_DECLARE_MET…

### DIFF
--- a/src/mqtt/qmqtt_client.h
+++ b/src/mqtt/qmqtt_client.h
@@ -233,6 +233,6 @@ private:
 
 } // namespace QMQTT
 
-Q_DECLARE_METATYPE(QMQTT::ClientError);
+Q_DECLARE_METATYPE(QMQTT::ClientError)
 
 #endif // QMQTT_CLIENT_H


### PR DESCRIPTION
Satisfy GCC pedantic build by removing extra semicolon, Q_DECLARE_METATYPE(..);