### PR TITLE
Fix for issue #129

### DIFF
--- a/src/mqtt/qmqtt_network.cpp
+++ b/src/mqtt/qmqtt_network.cpp
@@ -130,6 +130,8 @@ bool QMQTT::Network::isConnectedToHost() const
 
 void QMQTT::Network::connectToHost(const QHostAddress& host, const quint16 port)
 {
+    // Reset the hostname, because if it is not empty connectToHost() will use it instead of _host.
+    _hostName.clear();
     _host = host;
     _port = port;
     connectToHost();

--- a/src/mqtt/qmqtt_network.cpp
+++ b/src/mqtt/qmqtt_network.cpp
@@ -36,8 +36,6 @@
 #include "qmqtt_timer_p.h"
 #include "qmqtt_websocket_p.h"
 
-const QString DEFAULT_HOST_NAME = QStringLiteral("localhost");
-const QHostAddress DEFAULT_HOST = QHostAddress::LocalHost;
 const quint16 DEFAULT_PORT = 1883;
 const quint16 DEFAULT_SSL_PORT = 8883;
 const bool DEFAULT_AUTORECONNECT = false;
@@ -46,7 +44,6 @@ const int DEFAULT_AUTORECONNECT_INTERVAL_MS = 5000;
 QMQTT::Network::Network(QObject* parent)
     : NetworkInterface(parent)
     , _port(DEFAULT_PORT)
-    , _host(DEFAULT_HOST)
     , _autoReconnect(DEFAULT_AUTORECONNECT)
     , _autoReconnectInterval(DEFAULT_AUTORECONNECT_INTERVAL_MS)
     , _socket(new QMQTT::Socket)
@@ -60,7 +57,6 @@ QMQTT::Network::Network(QObject* parent)
 QMQTT::Network::Network(const QSslConfiguration &config, bool ignoreSelfSigned, QObject *parent)
     : NetworkInterface(parent)
     , _port(DEFAULT_SSL_PORT)
-    , _hostName(DEFAULT_HOST_NAME)
     , _autoReconnect(DEFAULT_AUTORECONNECT)
     , _autoReconnectInterval(DEFAULT_AUTORECONNECT_INTERVAL_MS)
     , _socket(new QMQTT::SslSocket(config, ignoreSelfSigned))
@@ -76,7 +72,6 @@ QMQTT::Network::Network(const QString& origin, QWebSocketProtocol::Version versi
                         bool ignoreSelfSigned, QObject* parent)
     : NetworkInterface(parent)
     , _port(DEFAULT_SSL_PORT)
-    , _hostName(DEFAULT_HOST_NAME)
     , _autoReconnect(DEFAULT_AUTORECONNECT)
     , _autoReconnectInterval(DEFAULT_AUTORECONNECT_INTERVAL_MS)
     , _socket(new QMQTT::WebSocket(origin, version, ignoreSelfSigned))
@@ -91,7 +86,6 @@ QMQTT::Network::Network(SocketInterface* socketInterface, TimerInterface* timerI
                         QObject* parent)
     : NetworkInterface(parent)
     , _port(DEFAULT_PORT)
-    , _host(DEFAULT_HOST)
     , _autoReconnect(DEFAULT_AUTORECONNECT)
     , _autoReconnectInterval(DEFAULT_AUTORECONNECT_INTERVAL_MS)
     , _socket(socketInterface)


### PR DESCRIPTION
Problem was that the Network class always sets a value in its _host member ("localhost"), which will be used if the user passes an QNetworkAddress in the constructor of Client, instead of the network address. This fix reset the _host member when a QNetworkAddress is supplied, which ensures that connectToHost() uses the network address instead of the hostname.

A second commit removes the default host, because it the user to the Client class is forced to supply a hostname or address, so the default will always be overwritten.
