### PR TITLE
Allow use of QSslConfiguration when setting up websocket connection.

### DIFF
--- a/src/mqtt/qmqtt_client.cpp
+++ b/src/mqtt/qmqtt_client.cpp
@@ -78,7 +78,20 @@ QMQTT::Client::Client(const QString& url,
     , d_ptr(new ClientPrivate(this))
 {
     Q_D(Client);
-    d->init(url, origin, version, ignoreSelfSigned);
+    d->init(url, origin, version, NULL, ignoreSelfSigned);
+}
+
+QMQTT::Client::Client(const QString& url,
+                      const QString& origin,
+                      QWebSocketProtocol::Version version,
+                      const QSslConfiguration& sslConfig,
+                      const bool ignoreSelfSigned,
+                      QObject* parent)
+    : QObject(parent)
+    , d_ptr(new ClientPrivate(this))
+{
+    Q_D(Client);
+    d->init(url, origin, version, &sslConfig, ignoreSelfSigned);
 }
 #endif // QT_WEBSOCKETS_LIB
 

--- a/src/mqtt/qmqtt_client.h
+++ b/src/mqtt/qmqtt_client.h
@@ -151,6 +151,13 @@ public:
            QWebSocketProtocol::Version version,
            bool ignoreSelfSigned = false,
            QObject* parent = NULL);
+
+    Client(const QString& url,
+           const QString& origin,
+           QWebSocketProtocol::Version version,
+           const QSslConfiguration& config,
+           const bool ignoreSelfSigned = false,
+           QObject* parent = NULL);
 #endif // QT_WEBSOCKETS_LIB
 
     // for testing purposes only

--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -119,12 +119,16 @@ void QMQTT::ClientPrivate::init(const QString& hostName, const quint16 port, con
 }
 
 #ifdef QT_WEBSOCKETS_LIB
-void QMQTT::ClientPrivate::init(const QString& url, const QString& origin,
-                                QWebSocketProtocol::Version version, bool ignoreSelfSigned)
+void QMQTT::ClientPrivate::init(const QString& url,
+                                const QString& origin,
+                                QWebSocketProtocol::Version version,
+                                const QSslConfiguration* sslConfig,
+                                bool ignoreSelfSigned)
 {
     _hostName = url;
-    init(new Network(origin, version, ignoreSelfSigned));
+    init(new Network(origin, version, sslConfig, ignoreSelfSigned));
 }
+
 #endif // QT_WEBSOCKETS_LIB
 
 void QMQTT::ClientPrivate::init(NetworkInterface* network)

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -60,7 +60,10 @@ public:
 #endif // QT_NO_SSL
     void init(const QString& hostName, const quint16 port, const bool ssl, const bool ignoreSelfSigned);
 #ifdef QT_WEBSOCKETS_LIB
-    void init(const QString& url, const QString &origin, QWebSocketProtocol::Version version,
+    void init(const QString& url,
+              const QString& origin,
+              QWebSocketProtocol::Version version,
+              const QSslConfiguration* sslConfig,
               bool ignoreSelfSigned);
 #endif // QT_WEBSOCKETS_LIB
     void init(NetworkInterface* network);

--- a/src/mqtt/qmqtt_network.cpp
+++ b/src/mqtt/qmqtt_network.cpp
@@ -68,13 +68,16 @@ QMQTT::Network::Network(const QSslConfiguration &config, bool ignoreSelfSigned, 
 #endif // QT_NO_SSL
 
 #ifdef QT_WEBSOCKETS_LIB
-QMQTT::Network::Network(const QString& origin, QWebSocketProtocol::Version version,
-                        bool ignoreSelfSigned, QObject* parent)
+QMQTT::Network::Network(const QString& origin,
+                        QWebSocketProtocol::Version version,
+                        const QSslConfiguration* sslConfig,
+                        bool ignoreSelfSigned,
+                        QObject* parent)
     : NetworkInterface(parent)
     , _port(DEFAULT_SSL_PORT)
     , _autoReconnect(DEFAULT_AUTORECONNECT)
     , _autoReconnectInterval(DEFAULT_AUTORECONNECT_INTERVAL_MS)
-    , _socket(new QMQTT::WebSocket(origin, version, ignoreSelfSigned))
+    , _socket(new QMQTT::WebSocket(origin, version, sslConfig, ignoreSelfSigned))
     , _autoReconnectTimer(new QMQTT::Timer)
     , _readState(Header)
 {

--- a/src/mqtt/qmqtt_network_p.h
+++ b/src/mqtt/qmqtt_network_p.h
@@ -63,7 +63,10 @@ public:
     Network(const QSslConfiguration& config, bool ignoreSelfSigned, QObject* parent = NULL);
 #endif // QT_NO_SSL
 #ifdef QT_WEBSOCKETS_LIB
-    Network(const QString& origin, QWebSocketProtocol::Version version, bool ignoreSelfSigned,
+    Network(const QString& origin,
+            QWebSocketProtocol::Version version,
+            const QSslConfiguration* sslConfig,
+            bool ignoreSelfSigned,
             QObject* parent = NULL);
 #endif // QT_WEBSOCKETS_LIB
     Network(SocketInterface* socketInterface, TimerInterface* timerInterface,

--- a/src/mqtt/qmqtt_websocket.cpp
+++ b/src/mqtt/qmqtt_websocket.cpp
@@ -4,13 +4,18 @@
 #include <QUrl>
 #include "qmqtt_websocket_p.h"
 
-QMQTT::WebSocket::WebSocket(const QString& origin, QWebSocketProtocol::Version version,
-                            bool ignoreSelfSigned, QObject* parent)
+QMQTT::WebSocket::WebSocket(const QString& origin,
+                            QWebSocketProtocol::Version version,
+                            const QSslConfiguration* sslConfig,
+                            bool ignoreSelfSigned,
+                            QObject* parent)
     : SocketInterface(parent)
     , _socket(new QWebSocket(origin, version, this))
     , _ioDevice(new WebSocketIODevice(_socket, this))
     , _ignoreSelfSigned(ignoreSelfSigned)
 {
+    if (sslConfig != NULL)
+        _socket->setSslConfiguration(*sslConfig);
     connect(_socket, &QWebSocket::connected, this, &WebSocket::connected);
     connect(_socket, &QWebSocket::disconnected, this, &WebSocket::disconnected);
     connect(_socket,

--- a/src/mqtt/qmqtt_websocket_p.h
+++ b/src/mqtt/qmqtt_websocket_p.h
@@ -36,6 +36,7 @@
 
 #include "qmqtt_socketinterface.h"
 #include "qmqtt_websocketiodevice_p.h"
+#include <QSslConfiguration>
 #include <QWebSocket>
 
 namespace QMQTT
@@ -44,7 +45,10 @@ namespace QMQTT
 class WebSocket : public SocketInterface
 {
 public:
-    WebSocket(const QString& origin, QWebSocketProtocol::Version version, bool ignoreSelfSigned,
+    WebSocket(const QString& origin,
+              QWebSocketProtocol::Version version,
+              const QSslConfiguration* sslConfig,
+              bool ignoreSelfSigned,
               QObject* parent = NULL);
     virtual ~WebSocket();
 
@@ -58,8 +62,6 @@ public:
     void disconnectFromHost();
     QAbstractSocket::SocketState state() const;
     QAbstractSocket::SocketError error() const;
-
-    // using SocketInterface::error;
 
 private slots:
     void sslErrors(const QList<QSslError> &errors);


### PR DESCRIPTION
This commit add a new constructor to QMQTT::Client which allows passing an SSL configuration when creation a websocket connection. This should fix issue #132.