### PR TITLE
 Modify the signal void connected() to void connected(const quint8 ack);

### DIFF
--- a/src/mqtt/qmqtt_client.h
+++ b/src/mqtt/qmqtt_client.h
@@ -206,7 +206,7 @@ public slots:
     quint16 publish(const QMQTT::Message& message);
 
 signals:
-    void connected();
+    void connected(const quint8 ack);
     void disconnected();
     void error(const QMQTT::ClientError error);
 

--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -425,8 +425,7 @@ void QMQTT::ClientPrivate::onNetworkReceived(const QMQTT::Frame& frm)
 void QMQTT::ClientPrivate::handleConnack(const quint8 ack)
 {
     Q_Q(Client);
-    Q_UNUSED(ack);
-    emit q->connected();
+    emit q->connected(ack);
 }
 
 void QMQTT::ClientPrivate::handlePublish(const Message& message)


### PR DESCRIPTION
After receiving the connack, the signal connected increases the Connect Return code parameter, which has solved the problem that if the connection fails, the return value is not 0.
Solve the [#133](https://github.com/emqtt/qmqtt/issues/133) problem.