### PR TITLE
add mqtt error type 

### DIFF
--- a/src/mqtt/qmqtt_client.h
+++ b/src/mqtt/qmqtt_client.h
@@ -67,6 +67,16 @@ enum ConnectionState
     STATE_CONNECTED,
     STATE_DISCONNECTED
 };
+namespace MqttError {
+    enum MqttError {
+        UnknownError = 0,
+        MqttUnacceptableProtocolVersionError,
+        MqttIdentifierRejectedError,
+        MqttServerUnavailableError,
+        MqttVadUserNameOrPasswordError,
+        MqttNotAuthorizedError
+    };
+}
 
 enum ClientError
 {
@@ -93,7 +103,12 @@ enum ClientError
     SocketOperationError,
     SocketSslInternalError,
     SocketSslInvalidUserDataError,
-    SocketTemporaryError
+    SocketTemporaryError,
+    MqttUnacceptableProtocolVersionError=1<<16,
+    MqttIdentifierRejectedError,
+    MqttServerUnavailableError,
+    MqttVadUserNameOrPasswordError,
+    MqttNotAuthorizedError
 };
 
 class ClientPrivate;

--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -440,8 +440,7 @@ void QMQTT::ClientPrivate::handleConnack(const quint8 ack)
     if (ack==0) {
         emit q->connected();
     }
-   emit q->error(_mqttErrorHash.value(MqttError::MqttError (ack), UnknownError));
-
+    emit q->error(_mqttErrorHash.value(MqttError::MqttError (ack), UnknownError));
 }
 
 void QMQTT::ClientPrivate::handlePublish(const Message& message)

--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -39,7 +39,6 @@
 #include <QSslConfiguration>
 #include <QSslKey>
 #endif // QT_NO_SSL
-#include <QDebug>
 
 Q_LOGGING_CATEGORY(client, "qmqtt.client")
 

--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -39,6 +39,7 @@
 #include <QSslConfiguration>
 #include <QSslKey>
 #endif // QT_NO_SSL
+#include <QDebug>
 
 Q_LOGGING_CATEGORY(client, "qmqtt.client")
 
@@ -175,6 +176,13 @@ void QMQTT::ClientPrivate::initializeErrorHash()
     _socketErrorHash.insert(QAbstractSocket::SslInternalError, SocketSslInternalError);
     _socketErrorHash.insert(QAbstractSocket::SslInvalidUserDataError, SocketSslInvalidUserDataError);
     _socketErrorHash.insert(QAbstractSocket::TemporaryError, SocketTemporaryError);
+
+    _mqttErrorHash.insert(MqttError::MqttUnacceptableProtocolVersionError, MqttUnacceptableProtocolVersionError);
+    _mqttErrorHash.insert(MqttError::MqttIdentifierRejectedError, MqttIdentifierRejectedError);
+    _mqttErrorHash.insert(MqttError::MqttServerUnavailableError, MqttServerUnavailableError);
+    _mqttErrorHash.insert(MqttError::MqttVadUserNameOrPasswordError, MqttVadUserNameOrPasswordError);
+    _mqttErrorHash.insert(MqttError::MqttNotAuthorizedError, MqttNotAuthorizedError);
+
 }
 
 void QMQTT::ClientPrivate::connectToHost()
@@ -429,8 +437,11 @@ void QMQTT::ClientPrivate::onNetworkReceived(const QMQTT::Frame& frm)
 void QMQTT::ClientPrivate::handleConnack(const quint8 ack)
 {
     Q_Q(Client);
-    Q_UNUSED(ack);
-    emit q->connected();
+    if (ack==0) {
+        emit q->connected();
+    }
+   emit q->error(_mqttErrorHash.value(MqttError::MqttError (ack), UnknownError));
+
 }
 
 void QMQTT::ClientPrivate::handlePublish(const Message& message)

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -89,6 +89,7 @@ public:
     bool _willRetain;
     QByteArray _willMessage;
     QHash<QAbstractSocket::SocketError, ClientError> _socketErrorHash;
+    QHash<MqttError::MqttError, ClientError> _mqttErrorHash;
     QHash<quint16, QString> _midToTopic;
     QHash<quint16, Message> _midToMessage;
 


### PR DESCRIPTION
add mqtt error type , Re-edit for pull [#135 ](https://github.com/emqtt/qmqtt/pull/135).
Solve the[ #133](https://github.com/emqtt/qmqtt/issues/133) problem.

Add enum ClientError element .
`MqttUnacceptableProtocolVersionError=1<<16,
    MqttIdentifierRejectedError,
    MqttServerUnavailableError,
    MqttVadUserNameOrPasswordError,
    MqttNotAuthorizedError`

Modify the handleConnack ack !=0 to issue an error message number.
`void QMQTT::ClientPrivate::handleConnack(const quint8 ack)
{
    Q_Q(Client);
    if (ack==0) {
        emit q->connected();
    }
   emit q->error(_mqttErrorHash.value(MqttError::MqttError (ack), UnknownError));

}`