### PR TITLE
Cleanup of pull request #136

### DIFF
--- a/src/mqtt/qmqtt_client.h
+++ b/src/mqtt/qmqtt_client.h
@@ -67,16 +67,6 @@ enum ConnectionState
     STATE_CONNECTED,
     STATE_DISCONNECTED
 };
-namespace MqttError {
-    enum MqttError {
-        UnknownError = 0,
-        MqttUnacceptableProtocolVersionError,
-        MqttIdentifierRejectedError,
-        MqttServerUnavailableError,
-        MqttVadUserNameOrPasswordError,
-        MqttNotAuthorizedError
-    };
-}
 
 enum ClientError
 {
@@ -107,7 +97,7 @@ enum ClientError
     MqttUnacceptableProtocolVersionError=1<<16,
     MqttIdentifierRejectedError,
     MqttServerUnavailableError,
-    MqttVadUserNameOrPasswordError,
+    MqttBadUserNameOrPasswordError,
     MqttNotAuthorizedError
 };
 

--- a/src/mqtt/qmqtt_client.h
+++ b/src/mqtt/qmqtt_client.h
@@ -67,6 +67,16 @@ enum ConnectionState
     STATE_CONNECTED,
     STATE_DISCONNECTED
 };
+namespace MqttError {
+    enum MqttError {
+        UnknownError = 0,
+        MqttUnacceptableProtocolVersionError,
+        MqttIdentifierRejectedError,
+        MqttServerUnavailableError,
+        MqttVadUserNameOrPasswordError,
+        MqttNotAuthorizedError
+    };
+}
 
 enum ClientError
 {
@@ -93,7 +103,12 @@ enum ClientError
     SocketOperationError,
     SocketSslInternalError,
     SocketSslInvalidUserDataError,
-    SocketTemporaryError
+    SocketTemporaryError,
+    MqttUnacceptableProtocolVersionError=1<<16,
+    MqttIdentifierRejectedError,
+    MqttServerUnavailableError,
+    MqttVadUserNameOrPasswordError,
+    MqttNotAuthorizedError
 };
 
 class ClientPrivate;

--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -137,8 +137,6 @@ void QMQTT::ClientPrivate::init(NetworkInterface* network)
 
     _network.reset(network);
 
-    initializeErrorHash();
-
     QObject::connect(&_timer, &QTimer::timeout, q, &Client::onTimerPingReq);
     QObject::connect(_network.data(), &Network::connected,
                      q, &Client::onNetworkConnected);
@@ -148,33 +146,6 @@ void QMQTT::ClientPrivate::init(NetworkInterface* network)
                      q, &Client::onNetworkReceived);
     QObject::connect(_network.data(), &Network::error,
                      q, &Client::onNetworkError);
-}
-
-void QMQTT::ClientPrivate::initializeErrorHash()
-{
-    _socketErrorHash.insert(QAbstractSocket::ConnectionRefusedError, SocketConnectionRefusedError);
-    _socketErrorHash.insert(QAbstractSocket::RemoteHostClosedError, SocketRemoteHostClosedError);
-    _socketErrorHash.insert(QAbstractSocket::HostNotFoundError, SocketHostNotFoundError);
-    _socketErrorHash.insert(QAbstractSocket::SocketAccessError, SocketAccessError);
-    _socketErrorHash.insert(QAbstractSocket::SocketResourceError, SocketResourceError);
-    _socketErrorHash.insert(QAbstractSocket::SocketTimeoutError, SocketTimeoutError);
-    _socketErrorHash.insert(QAbstractSocket::DatagramTooLargeError, SocketDatagramTooLargeError);
-    _socketErrorHash.insert(QAbstractSocket::NetworkError, SocketNetworkError);
-    _socketErrorHash.insert(QAbstractSocket::AddressInUseError, SocketAddressInUseError);
-    _socketErrorHash.insert(QAbstractSocket::SocketAddressNotAvailableError, SocketAddressNotAvailableError);
-    _socketErrorHash.insert(QAbstractSocket::UnsupportedSocketOperationError, SocketUnsupportedSocketOperationError);
-    _socketErrorHash.insert(QAbstractSocket::UnfinishedSocketOperationError, SocketUnfinishedSocketOperationError);
-    _socketErrorHash.insert(QAbstractSocket::ProxyAuthenticationRequiredError, SocketProxyAuthenticationRequiredError);
-    _socketErrorHash.insert(QAbstractSocket::SslHandshakeFailedError, SocketSslHandshakeFailedError);
-    _socketErrorHash.insert(QAbstractSocket::ProxyConnectionRefusedError, SocketProxyConnectionRefusedError);
-    _socketErrorHash.insert(QAbstractSocket::ProxyConnectionClosedError, SocketProxyConnectionClosedError);
-    _socketErrorHash.insert(QAbstractSocket::ProxyConnectionTimeoutError, SocketProxyConnectionTimeoutError);
-    _socketErrorHash.insert(QAbstractSocket::ProxyNotFoundError, SocketProxyNotFoundError);
-    _socketErrorHash.insert(QAbstractSocket::ProxyProtocolError, SocketProxyProtocolError);
-    _socketErrorHash.insert(QAbstractSocket::OperationError, SocketOperationError);
-    _socketErrorHash.insert(QAbstractSocket::SslInternalError, SocketSslInternalError);
-    _socketErrorHash.insert(QAbstractSocket::SslInvalidUserDataError, SocketSslInvalidUserDataError);
-    _socketErrorHash.insert(QAbstractSocket::TemporaryError, SocketTemporaryError);
 }
 
 void QMQTT::ClientPrivate::connectToHost()
@@ -676,5 +647,80 @@ void QMQTT::ClientPrivate::setWillMessage(const QByteArray& willMessage)
 void QMQTT::ClientPrivate::onNetworkError(QAbstractSocket::SocketError socketError)
 {
     Q_Q(Client);
-    emit q->error(_socketErrorHash.value(socketError, UnknownError));
+
+    switch (socketError)
+    {
+    case QAbstractSocket::ConnectionRefusedError:
+        emit q->error(SocketConnectionRefusedError);
+        break;
+    case QAbstractSocket::RemoteHostClosedError:
+        emit q->error(SocketRemoteHostClosedError);
+        break;
+    case QAbstractSocket::HostNotFoundError:
+        emit q->error(SocketHostNotFoundError);
+        break;
+    case QAbstractSocket::SocketAccessError:
+        emit q->error(SocketAccessError);
+        break;
+    case QAbstractSocket::SocketResourceError:
+        emit q->error(SocketResourceError);
+        break;
+    case QAbstractSocket::SocketTimeoutError:
+        emit q->error(SocketTimeoutError);
+        break;
+    case QAbstractSocket::DatagramTooLargeError:
+        emit q->error(SocketDatagramTooLargeError);
+        break;
+    case QAbstractSocket::NetworkError:
+        emit q->error(SocketNetworkError);
+        break;
+    case QAbstractSocket::AddressInUseError:
+        emit q->error(SocketAddressInUseError);
+        break;
+    case QAbstractSocket::SocketAddressNotAvailableError:
+        emit q->error(SocketAddressNotAvailableError);
+        break;
+    case QAbstractSocket::UnsupportedSocketOperationError:
+        emit q->error(SocketUnsupportedSocketOperationError);
+        break;
+    case QAbstractSocket::UnfinishedSocketOperationError:
+        emit q->error(SocketUnfinishedSocketOperationError);
+        break;
+    case QAbstractSocket::ProxyAuthenticationRequiredError:
+        emit q->error(SocketProxyAuthenticationRequiredError);
+        break;
+    case QAbstractSocket::SslHandshakeFailedError:
+        emit q->error(SocketSslHandshakeFailedError);
+        break;
+    case QAbstractSocket::ProxyConnectionRefusedError:
+        emit q->error(SocketProxyConnectionRefusedError);
+        break;
+    case QAbstractSocket::ProxyConnectionClosedError:
+        emit q->error(SocketProxyConnectionClosedError);
+        break;
+    case QAbstractSocket::ProxyConnectionTimeoutError:
+        emit q->error(SocketProxyConnectionTimeoutError);
+        break;
+    case QAbstractSocket::ProxyNotFoundError:
+        emit q->error(SocketProxyNotFoundError);
+        break;
+    case QAbstractSocket::ProxyProtocolError:
+        emit q->error(SocketProxyProtocolError);
+        break;
+    case QAbstractSocket::OperationError:
+        emit q->error(SocketOperationError);
+        break;
+    case QAbstractSocket::SslInternalError:
+        emit q->error(SocketSslInternalError);
+        break;
+    case QAbstractSocket::SslInvalidUserDataError:
+        emit q->error(SocketSslInvalidUserDataError);
+        break;
+    case QAbstractSocket::TemporaryError:
+        emit q->error(SocketTemporaryError);
+        break;
+    default:
+        emit q->error(UnknownError);
+        break;
+    }
 }

--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -39,6 +39,7 @@
 #include <QSslConfiguration>
 #include <QSslKey>
 #endif // QT_NO_SSL
+#include <QDebug>
 
 Q_LOGGING_CATEGORY(client, "qmqtt.client")
 
@@ -175,6 +176,13 @@ void QMQTT::ClientPrivate::initializeErrorHash()
     _socketErrorHash.insert(QAbstractSocket::SslInternalError, SocketSslInternalError);
     _socketErrorHash.insert(QAbstractSocket::SslInvalidUserDataError, SocketSslInvalidUserDataError);
     _socketErrorHash.insert(QAbstractSocket::TemporaryError, SocketTemporaryError);
+
+    _mqttErrorHash.insert(MqttError::MqttUnacceptableProtocolVersionError, MqttUnacceptableProtocolVersionError);
+    _mqttErrorHash.insert(MqttError::MqttIdentifierRejectedError, MqttIdentifierRejectedError);
+    _mqttErrorHash.insert(MqttError::MqttServerUnavailableError, MqttServerUnavailableError);
+    _mqttErrorHash.insert(MqttError::MqttVadUserNameOrPasswordError, MqttVadUserNameOrPasswordError);
+    _mqttErrorHash.insert(MqttError::MqttNotAuthorizedError, MqttNotAuthorizedError);
+
 }
 
 void QMQTT::ClientPrivate::connectToHost()
@@ -429,8 +437,11 @@ void QMQTT::ClientPrivate::onNetworkReceived(const QMQTT::Frame& frm)
 void QMQTT::ClientPrivate::handleConnack(const quint8 ack)
 {
     Q_Q(Client);
-    Q_UNUSED(ack);
-    emit q->connected();
+    if (ack==0) {
+        emit q->connected();
+    }
+   emit q->error(_mqttErrorHash.value(MqttError::MqttError (ack), UnknownError));
+
 }
 
 void QMQTT::ClientPrivate::handlePublish(const Message& message)

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -88,7 +88,6 @@ public:
     quint8 _willQos;
     bool _willRetain;
     QByteArray _willMessage;
-    QHash<QAbstractSocket::SocketError, ClientError> _socketErrorHash;
     QHash<quint16, QString> _midToTopic;
     QHash<quint16, Message> _midToMessage;
 
@@ -152,7 +151,6 @@ public:
     quint8 willQos() const;
     bool willRetain() const;
     QByteArray willMessage() const;
-    void initializeErrorHash();
     void onNetworkError(QAbstractSocket::SocketError error);
 
     Q_DECLARE_PUBLIC(Client)

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -89,6 +89,7 @@ public:
     bool _willRetain;
     QByteArray _willMessage;
     QHash<QAbstractSocket::SocketError, ClientError> _socketErrorHash;
+    QHash<MqttError::MqttError, ClientError> _mqttErrorHash;
     QHash<quint16, QString> _midToTopic;
     QHash<quint16, Message> _midToMessage;
 

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -89,7 +89,6 @@ public:
     bool _willRetain;
     QByteArray _willMessage;
     QHash<QAbstractSocket::SocketError, ClientError> _socketErrorHash;
-    QHash<MqttError::MqttError, ClientError> _mqttErrorHash;
     QHash<quint16, QString> _midToTopic;
     QHash<quint16, Message> _midToMessage;
 


### PR DESCRIPTION
This pull request contains the changes made in pull request #136 along with the changes proposed in the review (including mine).

The request also contains a commit that removes the hash used to convert so cket errors into QMQTT errors in favor of a switch statement. This would be (slightly) faster and reduce memory use.