### PR TITLE
Detect server failure to send PINGRESP

### DIFF
--- a/src/mqtt/qmqtt_client.cpp
+++ b/src/mqtt/qmqtt_client.cpp
@@ -338,6 +338,12 @@ void QMQTT::Client::onTimerPingReq()
     d->onTimerPingReq();
 }
 
+void QMQTT::Client::onPingTimeout()
+{
+    Q_D(Client);
+    d->onPingTimeout();
+}
+
 void QMQTT::Client::disconnectFromHost()
 {
     Q_D(Client);

--- a/src/mqtt/qmqtt_client.h
+++ b/src/mqtt/qmqtt_client.h
@@ -98,7 +98,8 @@ enum ClientError
     MqttIdentifierRejectedError,
     MqttServerUnavailableError,
     MqttBadUserNameOrPasswordError,
-    MqttNotAuthorizedError
+    MqttNotAuthorizedError,
+    MqttNoPingResponse
 };
 
 class ClientPrivate;
@@ -233,6 +234,7 @@ protected slots:
     void onNetworkDisconnected();
     void onNetworkReceived(const QMQTT::Frame& frame);
     void onTimerPingReq();
+    void onPingTimeout();
     void onNetworkError(QAbstractSocket::SocketError error);
 
 protected:

--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -473,7 +473,8 @@ void QMQTT::ClientPrivate::handlePuback(const quint8 type, const quint16 msgid)
     }
 }
 
-void QMQTT::ClientPrivate::handlePingresp() {
+void QMQTT::ClientPrivate::handlePingresp()
+{
     // Stop the ping response timer to prevent disconnection. It will be restarted when the next
     // ping request has been sent.
     _pingResponseTimer.stop();
@@ -481,7 +482,8 @@ void QMQTT::ClientPrivate::handlePingresp() {
     emit q->pingresp();
 }
 
-void QMQTT::ClientPrivate::handleSuback(const QString &topic, const quint8 qos) {
+void QMQTT::ClientPrivate::handleSuback(const QString &topic, const quint8 qos)
+{
     Q_Q(Client);
     emit q->subscribed(topic, qos);
 }

--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -53,12 +53,12 @@ QMQTT::ClientPrivate::ClientPrivate(Client* qq_ptr)
     , _version(MQTTVersion::V3_1_0)
     , _clientId(QUuid::createUuid().toString())
     , _cleanSession(false)
-    , _keepAlive(300)
     , _connectionState(STATE_INIT)
     , _willQos(0)
     , _willRetain(false)
     , q_ptr(qq_ptr)
 {
+    setKeepAlive(300);
 }
 
 QMQTT::ClientPrivate::~ClientPrivate()
@@ -136,8 +136,11 @@ void QMQTT::ClientPrivate::init(NetworkInterface* network)
     Q_Q(Client);
 
     _network.reset(network);
+    _timer.setSingleShot(true);
+    _pingResponseTimer.setSingleShot(true);
 
     QObject::connect(&_timer, &QTimer::timeout, q, &Client::onTimerPingReq);
+    QObject::connect(&_pingResponseTimer, &QTimer::timeout, q, &Client::onPingTimeout);
     QObject::connect(_network.data(), &Network::connected,
                      q, &Client::onNetworkConnected);
     QObject::connect(_network.data(), &Network::disconnected,
@@ -163,7 +166,6 @@ void QMQTT::ClientPrivate::connectToHost()
 void QMQTT::ClientPrivate::onNetworkConnected()
 {
     sendConnect();
-    startKeepAlive();
 }
 
 void QMQTT::ClientPrivate::sendConnect()
@@ -199,7 +201,7 @@ void QMQTT::ClientPrivate::sendConnect()
     }
     frame.writeChar(_version);
     frame.writeChar(flags);
-    frame.writeInt(_keepAlive);
+    frame.writeInt(keepAlive());
     frame.writeString(_clientId);
     if(!willTopic().isEmpty())
     {
@@ -217,7 +219,7 @@ void QMQTT::ClientPrivate::sendConnect()
             frame.writeByteArray(_password);
         }
     }
-    _network->sendFrame(frame);
+    sendFrame(frame);
 }
 
 quint16 QMQTT::ClientPrivate::sendPublish(const Message &message)
@@ -238,7 +240,7 @@ quint16 QMQTT::ClientPrivate::sendPublish(const Message &message)
     if(!message.payload().isEmpty()) {
         frame.writeRawData(message.payload());
     }
-    _network->sendFrame(frame);
+    sendFrame(frame);
     return msgid;
 }
 
@@ -246,7 +248,7 @@ void QMQTT::ClientPrivate::sendPuback(const quint8 type, const quint16 mid)
 {
     Frame frame(type);
     frame.writeInt(mid);
-    _network->sendFrame(frame);
+    sendFrame(frame);
 }
 
 quint16 QMQTT::ClientPrivate::sendSubscribe(const QString & topic, const quint8 qos)
@@ -256,7 +258,7 @@ quint16 QMQTT::ClientPrivate::sendSubscribe(const QString & topic, const quint8 
     frame.writeInt(mid);
     frame.writeString(topic);
     frame.writeChar(qos);
-    _network->sendFrame(frame);
+    sendFrame(frame);
     return mid;
 }
 
@@ -266,14 +268,22 @@ quint16 QMQTT::ClientPrivate::sendUnsubscribe(const QString &topic)
     Frame frame(SETQOS(UNSUBSCRIBE, QOS1));
     frame.writeInt(mid);
     frame.writeString(topic);
-    _network->sendFrame(frame);
+    sendFrame(frame);
     return mid;
 }
 
 void QMQTT::ClientPrivate::onTimerPingReq()
 {
     Frame frame(PINGREQ);
-    _network->sendFrame(frame);
+    sendFrame(frame);
+    _pingResponseTimer.start();
+}
+
+void QMQTT::ClientPrivate::onPingTimeout()
+{
+    Q_Q(Client);
+    emit q->error(MqttNoPingResponse);
+    disconnectFromHost();
 }
 
 void QMQTT::ClientPrivate::disconnectFromHost()
@@ -285,18 +295,19 @@ void QMQTT::ClientPrivate::disconnectFromHost()
 void QMQTT::ClientPrivate::sendDisconnect()
 {
     Frame frame(DISCONNECT);
-    _network->sendFrame(frame);
+    sendFrame(frame);
 }
 
-void QMQTT::ClientPrivate::startKeepAlive()
+void QMQTT::ClientPrivate::sendFrame(const Frame &frame)
 {
-    _timer.setInterval(_keepAlive*1000);
+    _network->sendFrame(frame);
     _timer.start();
 }
 
 void QMQTT::ClientPrivate::stopKeepAlive()
 {
     _timer.stop();
+    _pingResponseTimer.stop();
 }
 
 quint16 QMQTT::ClientPrivate::nextmid()
@@ -463,6 +474,9 @@ void QMQTT::ClientPrivate::handlePuback(const quint8 type, const quint16 msgid)
 }
 
 void QMQTT::ClientPrivate::handlePingresp() {
+    // Stop the ping response timer to prevent disconnection. It will be restarted when the next
+    // ping request has been sent.
+    _pingResponseTimer.stop();
     Q_Q(Client);
     emit q->pingresp();
 }
@@ -519,12 +533,16 @@ bool QMQTT::ClientPrivate::cleanSession() const
 
 void QMQTT::ClientPrivate::setKeepAlive(const quint16 keepAlive)
 {
-    _keepAlive = keepAlive;
+    // _timer will be started when a message is sent.
+    _timer.setInterval(keepAlive*1000);
+    // The MQTT specification does not mention a timeout value in this case, so we use 10% of the
+    // keep alive interval.
+    _pingResponseTimer.setInterval(qBound(keepAlive * 100, 10000, keepAlive * 1000));
 }
 
 quint16 QMQTT::ClientPrivate::keepAlive() const
 {
-    return _keepAlive;
+    return _timer.interval() / 1000;
 }
 
 void QMQTT::ClientPrivate::setPassword(const QByteArray& password)

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -80,10 +80,10 @@ public:
     QString _username;
     QByteArray _password;
     bool _cleanSession;
-    quint16 _keepAlive;
     ConnectionState _connectionState;
     QScopedPointer<NetworkInterface> _network;
     QTimer _timer;
+    QTimer _pingResponseTimer;
     QString _willTopic;
     quint8 _willQos;
     bool _willRetain;
@@ -97,13 +97,14 @@ public:
     void connectToHost();
     void sendConnect();
     void onTimerPingReq();
+    void onPingTimeout();
     quint16 sendUnsubscribe(const QString &topic);
     quint16 sendSubscribe(const QString &topic, const quint8 qos);
     quint16 sendPublish(const Message &message);
     void sendPuback(const quint8 type, const quint16 mid);
     void sendDisconnect();
+    void sendFrame(const Frame &frame);
     void disconnectFromHost();
-    void startKeepAlive();
     void stopKeepAlive();
     void onNetworkConnected();
     void onNetworkDisconnected();

--- a/src/mqtt/qmqtt_frame.cpp
+++ b/src/mqtt/qmqtt_frame.cpp
@@ -162,7 +162,7 @@ void Frame::writeRawData(const QByteArray &data)
     _data.append(data);
 }
 
-void Frame::write(QDataStream &stream)
+void Frame::write(QDataStream &stream) const
 {
     QByteArray lenbuf;
 
@@ -188,7 +188,7 @@ void Frame::write(QDataStream &stream)
     }
 }
 
-bool Frame::encodeLength(QByteArray &lenbuf, int length)
+bool Frame::encodeLength(QByteArray &lenbuf, int length) const
 {
     lenbuf.clear();
     quint8 d;

--- a/src/mqtt/qmqtt_frame.h
+++ b/src/mqtt/qmqtt_frame.h
@@ -118,8 +118,8 @@ public:
     void writeRawData(const QByteArray &data);
 
     //TODO: FIXME LATER
-    void write(QDataStream &stream);
-    bool encodeLength(QByteArray &lenbuf, int length);
+    void write(QDataStream &stream) const;
+    bool encodeLength(QByteArray &lenbuf, int length) const;
 
 private:
     quint8 _header;

--- a/src/mqtt/qmqtt_network.cpp
+++ b/src/mqtt/qmqtt_network.cpp
@@ -163,7 +163,7 @@ void QMQTT::Network::onSocketError(QAbstractSocket::SocketError socketError)
     }
 }
 
-void QMQTT::Network::sendFrame(Frame& frame)
+void QMQTT::Network::sendFrame(const Frame& frame)
 {
     if(_socket->state() == QAbstractSocket::ConnectedState)
     {

--- a/src/mqtt/qmqtt_network_p.h
+++ b/src/mqtt/qmqtt_network_p.h
@@ -73,7 +73,7 @@ public:
             QObject* parent = NULL);
     ~Network();
 
-    void sendFrame(Frame& frame);
+    void sendFrame(const Frame &frame);
     bool isConnectedToHost() const;
     bool autoReconnect() const;
     void setAutoReconnect(const bool autoReconnect);

--- a/src/mqtt/qmqtt_networkinterface.h
+++ b/src/mqtt/qmqtt_networkinterface.h
@@ -46,7 +46,7 @@ public:
     explicit NetworkInterface(QObject* parent = NULL) : QObject(parent) {}
     virtual ~NetworkInterface() {}
 
-    virtual void sendFrame(Frame& frame) = 0;
+    virtual void sendFrame(const Frame& frame) = 0;
     virtual bool isConnectedToHost() const = 0;
     virtual bool autoReconnect() const = 0;
     virtual void setAutoReconnect(const bool autoReconnect) = 0;

--- a/tests/gtest/tests/networkmock.h
+++ b/tests/gtest/tests/networkmock.h
@@ -7,7 +7,7 @@
 class NetworkMock : public QMQTT::NetworkInterface
 {
 public:
-    MOCK_METHOD1(sendFrame, void(QMQTT::Frame&));
+    MOCK_METHOD1(sendFrame, void(const QMQTT::Frame&));
     MOCK_CONST_METHOD0(isConnectedToHost, bool());
     MOCK_CONST_METHOD0(autoReconnect, bool());
     MOCK_METHOD1(setAutoReconnect, void(const bool));


### PR DESCRIPTION
Added a minimal implementation which will disconnect if no ping response is received from the server after a the client has sent a ping request. (Issue #139).

The implementation will start a timer when the ping request has been sent. On timeout the connection will be closed, and a signal will be emitted by the client. The timeout interval is set at 10% of the keep alive interval. Nothing special is done for reconnection, which still depends on the autoReconnect property.

Note that I cannot test the changes, because I don't know how to disable/block PINGRESP messages from the broker, so a code review or some additional testing would be appreciated.
