### PR TITLE
Fixed return type of ClientPrivate::autoReconnectInterval()

### DIFF
--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -503,7 +503,7 @@ void QMQTT::ClientPrivate::setAutoReconnect(const bool autoReconnect)
     _network->setAutoReconnect(autoReconnect);
 }
 
-bool QMQTT::ClientPrivate::autoReconnectInterval() const
+int QMQTT::ClientPrivate::autoReconnectInterval() const
 {
     return _network->autoReconnectInterval();
 }

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -122,7 +122,7 @@ public:
     void handlePingresp();
     bool autoReconnect() const;
     void setAutoReconnect(const bool autoReconnect);
-    bool autoReconnectInterval() const;
+    int autoReconnectInterval() const;
     void setAutoReconnectInterval(const int autoReconnectInterval);
     bool isConnectedToHost() const;
     QMQTT::ConnectionState connectionState() const;


### PR DESCRIPTION
The incorrect type was causing Client::autoReconenctInterval() to
return 1 instead of the actual interval value.