### PR TITLE
Fixed invalid connect frame if last will message is empty

### DIFF
--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -206,7 +206,7 @@ void QMQTT::ClientPrivate::sendConnect()
     if(!willTopic().isEmpty())
     {
         frame.writeString(willTopic());
-        // Transmit last will message even if it is empty, otherwise an invalid connect frame is send (user name is 
+        // Transmit last will message even if it is empty, otherwise an invalid connect frame is sent (user name is 
         // interpreted as will message and password as user name)
         frame.writeByteArray(_willMessage); 
     }

--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -206,8 +206,8 @@ void QMQTT::ClientPrivate::sendConnect()
     if(!willTopic().isEmpty())
     {
         frame.writeString(willTopic());
-        // Transmit last will message even if it is empty, otherwise an invalid connect frame is sent (user name is 
-        // interpreted as will message and password as user name)
+        // According to the specs (http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718031)
+        // the will message gets always sent together with the topic, also when it is empty which is perfectly valid.
         frame.writeByteArray(_willMessage); 
     }
     if (!_username.isEmpty())

--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -206,10 +206,9 @@ void QMQTT::ClientPrivate::sendConnect()
     if(!willTopic().isEmpty())
     {
         frame.writeString(willTopic());
-        if(!willMessage().isEmpty())
-        {
-            frame.writeByteArray(_willMessage);
-        }
+        // Transmit last will message even if it is empty, otherwise an invalid connect frame is send (user name is 
+        // interpreted as will message and password as user name)
+        frame.writeByteArray(_willMessage); 
     }
     if (!_username.isEmpty())
     {


### PR DESCRIPTION
Transmit last will message even if it is empty, otherwise an invalid connect frame is send (user name is interpreted as will message and password as user name)