### PR TITLE
Fix for issue  #154

### DIFF
--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -456,19 +456,19 @@ void QMQTT::ClientPrivate::handlePuback(const quint8 type, const quint16 msgid)
 {
     Q_Q(Client);
 
-    if(type == PUBREC)
+    switch (type)
     {
-        sendPuback(PUBREL, msgid);
-    }
-    else if (type == PUBREL)
-    {
+    case PUBREC:
+        sendPuback(SETQOS(PUBREL, QOS1), msgid);
+        break;
+    case PUBREL:
         sendPuback(PUBCOMP, msgid);
-    }
-    else if (type == PUBACK || type == PUBCOMP)
-    {
+        break;
+    case PUBACK:
+    case PUBCOMP:
         // Emit published on PUBACK at QOS1 and on PUBCOMP at QOS2
-        const Message &message = _midToMessage.take(msgid);
-        emit q->published(message, msgid);
+        emit q->published(_midToMessage.take(msgid), msgid);
+        break;
     }
 }
 

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -118,7 +118,6 @@ public:
     void handlePuback(const quint8 type, const quint16 msgid);
     void handleSuback(const QString& topic, const quint8 qos);
     void handleUnsuback(const QString& topic);
-    void handlePubcomp(const Message& message);
     void handlePingresp();
     bool autoReconnect() const;
     void setAutoReconnect(const bool autoReconnect);


### PR DESCRIPTION
Always set bit 2 (aka QOS1) in the package header when sending a PUBREL message.
