### PR TITLE
Added missing QString include - fixes incomplete type ‘QString’.

### DIFF
--- a/src/mqtt/qmqtt_message_p.h
+++ b/src/mqtt/qmqtt_message_p.h
@@ -34,6 +34,8 @@
 
 #include <QtCore/qshareddata.h>
 
+#include <QString>
+
 namespace QMQTT {
 
 class MessagePrivate : public QSharedData


### PR DESCRIPTION
In (realy strange) case of usage QMQTT without compiling as library (means - directly using headers (public/private) and sources in project), GCC produces next error:

```
third_party/qmqtt-master/src/mqtt/qmqtt_message_p.h:75:13: error: field ‘topic’ has incomplete type ‘QString’
     QString topic;
             ^
third_party/qmqtt-master/src/mqtt/qmqtt_message.cpp: In member function ‘QString QMQTT::Message::topic() const’:
third_party/qmqtt-master/src/mqtt/qmqtt_message.cpp:115:26: error: return type ‘class QString’ is incomplete
 QString Message::topic() const
                          ^
```
Adding this include fixes it.

OS: GNU/Linux, Debian, 
Arch: ARM
Qt version: 5.3.2
GCC: 4.9.2